### PR TITLE
"View PDF" button on citation tooltip (new)

### DIFF
--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -1,15 +1,14 @@
 import axios, { AxiosResponse } from "axios";
-import { isS2ApiResponseSuccess, S2ApiPaper } from "./types/s2-api";
+import { isS2ApiResponseSuccess, S2ApiPaperResponse } from "./types/s2-api";
 
 /**
  * Base URL for requests to Semantic Scholar API.
  */
-const SEMANTIC_SCHOLAR_API_URL = "http://api.semanticscholar.org/v1";
+const SEMANTIC_SCHOLAR_API_URL = "http://www.semanticscholar.org/api/1";
 
 interface Author {
   id: string;
   name: string;
-  url: string;
 }
 
 interface Paper {
@@ -17,11 +16,12 @@ interface Paper {
   title: string;
   authors: Author[];
   abstract: string | null;
-  url: string;
   venue: string | null;
   year: number | null;
   citationVelocity: number;
   influentialCitationCount: number;
+  primaryPaperLink: string;
+  primaryPaperLinkType: string;
 }
 
 /**
@@ -49,22 +49,30 @@ async function getPaper(s2Id: string): Promise<Paper | undefined> {
     return;
   }
   if (isS2ApiResponseSuccess(response)) {
-    const data = response.data as S2ApiPaper;
-    const year = parseInt(data.year) || null;
+    const data = response.data as S2ApiPaperResponse;
+    if (data.paper === undefined) {
+      return;
+    }
+    var year;
+    if (data.paper.year.text === undefined) {
+      year = null;
+    } else {
+      year = parseInt(data.paper.year.text)
+    }
     return {
       s2Id,
-      title: data.title,
-      authors: data.authors.map(a => ({
-        id: a.authorId,
+      title: data.paper.title.text,
+      authors: data.paper.authors[0].map(a => ({
+        id: a.ids,
         name: a.name,
-        url: a.url
       })),
-      abstract: data.abstract,
-      url: data.url,
+      abstract: data.paper.paperAbstract.text,
       year,
-      venue: data.venue,
-      citationVelocity: data.citationVelocity || 0,
-      influentialCitationCount: data.influentialCitationCount || 0
+      venue: data.paper.venue.text,
+      citationVelocity: data.paper.citationStats.citationVelocity || 0,
+      influentialCitationCount: data.paper.citationStats.numKeyCitations || 0,
+      primaryPaperLink: data.paper.primaryPaperLink.url,
+      primaryPaperLinkType: data.paper.primaryPaperLink.linkType,
     };
   }
 }

--- a/api/src/types/s2-api.ts
+++ b/api/src/types/s2-api.ts
@@ -13,21 +13,53 @@ interface S2ApiSuccess {
   status: 200;
 }
 
-export interface S2ApiPaper {
-  abstract: string;
-  arxivId: string | null;
-  authors: S2ApiAuthor[];
-  doi: string;
-  title: string;
+export interface S2ApiPaperResponse {
+  paper: S2ApiPaper;
+}
+
+interface S2ApiPaper {
+  id: string;
+  title: S2ApiTitle;
+  paperAbstract: S2ApiAbstract;
+  authors: S2ApiAuthor[][];
+  year: S2ApiYear;
+  venue: S2ApiVenue;
+  primaryPaperLink: S2ApiPaperLink;
+  doiInfo: S2ApiDoi;
+  citationStats: S2ApiCitationStats;
+}
+
+interface S2ApiTitle {
+  text: string;
+}
+
+interface S2ApiAbstract {
+  text: string;
+}
+
+interface S2ApiYear {
+  text: string;
+}
+
+interface S2ApiVenue {
+  text: string;
+}
+
+interface S2ApiPaperLink {
   url: string;
-  venue: string;
-  year: string;
-  influentialCitationCount?: number;
-  citationVelocity?: number;
+  linkType: string;
+}
+
+interface S2ApiDoi {
+  doi: String;
+}
+
+interface S2ApiCitationStats {
+  citationVelocity: number;
+  numKeyCitations: number;
 }
 
 interface S2ApiAuthor {
-  authorId: string;
+  ids: string;
   name: string;
-  url: string;
 }

--- a/ui/src/AuthorList.tsx
+++ b/ui/src/AuthorList.tsx
@@ -20,11 +20,12 @@ class AuthorList extends React.PureComponent<AuthorListProps, {}> {
           } else {
             textConnector = ", ";
           }
+          var authorUrl = `https://www.semanticscholar.org/author/{author.id}`
           return (
             <span key={author.id}>
               {textConnector}
               {this.props.showLinks && (
-                <S2Link url={author.url}>{author.name}</S2Link>
+                <S2Link url={authorUrl}>{author.name}</S2Link>
               )}
               {!this.props.showLinks && <>{author.name}</>}
             </span>

--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -11,7 +11,7 @@ import { userLibraryUrl } from "./s2-url";
 import S2Link from "./S2Link";
 import { ScholarReaderContext } from "./state";
 import { UserLibrary } from "./types/api";
-import { truncateText } from "./ui-utils";
+import { truncateText, getLinkText } from "./ui-utils";
 
 function warnOfUnimplementedActionAndTrack(
   actionType: string,
@@ -50,7 +50,7 @@ interface PaperSummaryState {
 export class PaperSummary extends React.PureComponent<
   PaperSummaryProps,
   PaperSummaryState
-> {
+  > {
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 
@@ -84,8 +84,8 @@ export class PaperSummary extends React.PureComponent<
       warnOfUnimplementedActionAndTrack(
         "save",
         "Before you can save papers to your library, you must be logged " +
-          "into Semantic Scholar. Visit https://semanticscholar.org to log in. " +
-          "Then refresh this page and try again."
+        "into Semantic Scholar. Visit https://semanticscholar.org to log in. " +
+        "Then refresh this page and try again."
       );
     } else {
       try {
@@ -126,6 +126,7 @@ export class PaperSummary extends React.PureComponent<
           const inLibrary = userLibrary
             ? userLibrary.paperIds.includes(this.props.paperId)
             : false;
+          const pdpUrl = `https://www.semanticscholar.org/paper/{paper.s2Id}`
 
           return (
             <div
@@ -148,7 +149,7 @@ export class PaperSummary extends React.PureComponent<
               {/* Paper details */}
               <div className="paper-summary__section">
                 <p className="paper-summary__title">
-                  <S2Link url={paper.url}>{paper.title}</S2Link>
+                  <S2Link url={pdpUrl}>{paper.title}</S2Link>
                 </p>
                 <p>
                   {paper.authors.length > 0 && (
@@ -163,26 +164,32 @@ export class PaperSummary extends React.PureComponent<
                 <div className="paper-summary__section">
                   <p className="paper-summary__abstract">
                     {this.state.showFullAbstract ||
-                    truncatedAbstract === paper.abstract ? (
-                      paper.abstract
-                    ) : (
-                      <>
-                        {truncatedAbstract}
-                        <span
-                          className="paper-summary__abstract__show-more-label"
-                          onClick={() => {
-                            this.setState({ showFullAbstract: true });
-                          }}
-                        >
-                          (show more)
+                      truncatedAbstract === paper.abstract ? (
+                        paper.abstract
+                      ) : (
+                        <>
+                          {truncatedAbstract}
+                          <span
+                            className="paper-summary__abstract__show-more-label"
+                            onClick={() => {
+                              this.setState({ showFullAbstract: true });
+                            }}
+                          >
+                            (show more)
                         </span>
-                      </>
-                    )}
+                        </>
+                      )}
                   </p>
                 </div>
               )}
 
               {/* Actions */}
+
+              <div className="paper-summary__actions">
+                <a href={paper.primaryPaperLink} target="_blank" rel="noopener noreferrer">
+                  <button className="paper-summary__view-pdf">{getLinkText(paper.primaryPaperLinkType)}</button>
+                </a>
+              </div>
               <div className="paper-summary__metrics-and-actions paper-summary__section">
                 {hasMetrics ? (
                   <div className="paper-summary__metrics">
@@ -235,11 +242,11 @@ export class PaperSummary extends React.PureComponent<
                 </Button>
                 {inLibrary
                   ? this.renderLibraryButton("In Your Library", () =>
-                      goToLibrary()
-                    )
+                    goToLibrary()
+                  )
                   : this.renderLibraryButton("Save To Library", () =>
-                      this.saveToLibrary(userLibrary, addToLibrary, paper.title)
-                    )}
+                    this.saveToLibrary(userLibrary, addToLibrary, paper.title)
+                  )}
               </div>
 
               <div className="paper-summary__section paper-summary__feedback">

--- a/ui/src/style/paper-summary.less
+++ b/ui/src/style/paper-summary.less
@@ -73,6 +73,29 @@
   color: @s2-error;
 }
 
+.paper-summary__actions {
+  padding-top: @medium / 2;
+}
+
+.paper-summary__view-pdf {
+  background: @s2-primary-action-background-color;
+  color: @white;
+  font-size: @s2-primary-action-font-size;
+  line-height: normal;
+  padding: @s2-primary-action-padding-top @s2-primary-action-padding-side;
+  border: @border-width solid transparent;
+  border-radius: @s2-primary-action-radius;
+  justify-content: center;
+  margin: @s2-primary-action-margin;
+  font-weight: @s2-primary-action-font-weight;
+  font-family: Roboto;
+
+  &:hover {
+    cursor: pointer;
+    background: @s2-primary-action-hover-color;
+  }
+}
+
 /**
  * Metrics
  */

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -17,6 +17,9 @@
 @equation-user-annotation-color: #e82;
 @symbol-user-annotation-color: #f5f;
 
+@s2-primary-action-background-color: #1857b6;
+@s2-primary-action-hover-color: #1f6de2;
+
 /**
  * S2 COLORS
  */
@@ -57,6 +60,8 @@
  */
 @large: 1.6rem;
 @medium: 1.4rem;
+@s2-primary-action-font-size: 14px;
+@s2-primary-action-font-weight: 400;
 
 /**
  * SPACE
@@ -64,6 +69,14 @@
 @padding: @medium;
 @margin: @medium;
 @tooltip-content-vertical-padding: @medium * 0.5;
+
+/**
+ * S2 PRIMARY ACTION
+ */
+@s2-primary-action-padding-top: 5px;
+@s2-primary-action-padding-side: 10px;
+@s2-primary-action-radius: 3px;
+@s2-primary-action-margin: 0;
 
 /**
  * ELEMENT DIMENSIONS

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -30,7 +30,6 @@ export interface BoundingBox {
 export interface Author {
   id: string;
   name: string;
-  url: string;
 }
 
 export interface PaperIdWithCounts {
@@ -45,11 +44,12 @@ export interface Paper {
   title: string;
   authors: Author[];
   abstract: string | null;
-  url: string;
   venue: string | null;
   year: number | null;
   citationVelocity: number;
   influentialCitationCount: number;
+  primaryPaperLink: string;
+  primaryPaperLinkType: string;
 }
 
 export interface Entity {

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -72,6 +72,52 @@ export function truncateText(
 }
 
 /**
+ * Get the correct display name for certain publishers.
+ * @param linkType the type of primaryPaperLink
+ */
+export function getLinkText(linkType: string): string {
+  var linkText: string = "";
+  const linkTextLengthLimit = 17;
+
+  if (linkType.length > linkTextLengthLimit) {
+    return "View Via Publisher"
+  }
+
+  switch (linkType) {
+    case "acm":
+      return "View On ACM"
+    case "anansi":
+      return "View Paper"
+    case "arxiv":
+      return "View On ArXiv"
+    case "dblp":
+      return "View Paper"
+    case "doi":
+      return "View Via Publisher"
+    case "educause":
+      return "View On Educause"
+    case "ieee":
+      return "View On IEEE"
+    case "institutional":
+      return "Check Your Institution"
+    case "medline":
+      return "View On PubMed"
+    case "s2":
+      return "View Paper"
+    case "wiley":
+      return "View Via Publisher"
+    default:
+      linkText = "View On " + linkType;
+  }
+
+  if (linkType === "publisher") {
+    linkText = "View Via Publisher"
+  }
+
+  return linkText;
+}
+
+/**
  * Call this function whenever you want to get the width and height of a pageView object from
  * PDF.js. This function avoids gotchas in computing the size of the page view. Width and
  * height are returned in pixels.


### PR DESCRIPTION
This PR contains revision from PR #106 , which is closed because it could no longer accept new commits due to git rebase command not working the way we wanted it to on my local repo).

Most of the comments on the old PR have been resolved except for the one concerning the declaration of `primaryPaperLink` and `primaryPaperLinkType`. Some of the older papers on semantic scholar weren't not published online, therefore the `s2ApiPaperResponse` for those paper do not contain properties such as `primaryPaperLink`. 

Here's a preview of the new tooltip with the added button:
![image](https://user-images.githubusercontent.com/52334652/84102546-a2035400-a9c5-11ea-8e12-fd14532e5eea.png)
