### PR TITLE
Support larger request headers in API server

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,8 +4,8 @@
   "description": "API for the Semantic Scholar Reader",
   "main": "index.js",
   "scripts": {
-    "start": "ts-node-dev src/index.ts",
-    "start:prod": "node build/index.js",
+    "start": "ts-node-dev --max-http-header-size=65536 src/index.ts",
+    "start:prod": "node --max-http-header-size=65536 build/index.js",
     "test": "jest",
     "build": "tsc --outDir build/"
   },


### PR DESCRIPTION
Ref https://github.com/allenai/scholar/issues/24644

Turns out it wasn't that bad, just had to dig through a bunch of documentation to find that the CLI arg still worked when using `ts-node-dev` instead of straight `node` 😄  The value of 64k comes from the online-service config, to keep it all in sync.

Tested by sending a request to the healthcheck API (/health) with a very large value in its header and witnessing the HTTP400 response, then restarting the server with the arg in place, repeating the request, and witnessing the HTTP200 response.