### PR TITLE
Increase request header limit for nginx

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -102,7 +102,6 @@ function(
             annotations: annotations + {
                 'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
                 'kubernetes.io/ingress.class': 'nginx',
-                'nginx.ingress.kubernetes.io/configuration-snippet': 'client_header_buffer_size 64k;\n large_client_header_buffers 4 64k',
                 'nginx.ingress.kubernetes.io/ssl-redirect': 'true'
             }
         },

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -17,7 +17,7 @@ function(
     // We only allow registration of hostnames attached to '*.apps.allenai.org'
     // at this point. If you need a custom domain, contact us: reviz@allenai.org.
     local topLevelDomain = '.apps.allenai.org';
-    local hosts = 
+    local hosts =
         if env == 'prod' then
             [ config.appName + topLevelDomain, 'scholarphi.semanticscholar.org' ]
         else
@@ -102,6 +102,7 @@ function(
             annotations: annotations + {
                 'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
                 'kubernetes.io/ingress.class': 'nginx',
+                'nginx.ingress.kubernetes.io/configuration-snippet': 'client_header_buffer_size 64k;\n large_client_header_buffers 4 64k',
                 'nginx.ingress.kubernetes.io/ssl-redirect': 'true'
             }
         },

--- a/ingress/nginx.conf
+++ b/ingress/nginx.conf
@@ -29,7 +29,6 @@ http {
     #   Needs to match the following:
     #   - --max-http-header-size flag (for node, see package.json)
     #   - nginx.conf (in /ui)
-    client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
 
     # Don't tell everyone we're running nginx, security through obscurity and

--- a/ingress/nginx.conf
+++ b/ingress/nginx.conf
@@ -25,6 +25,13 @@ http {
 
     gzip  on;
 
+    # Header size (set in sync with the S2 webapp)
+    #   Needs to match the following:
+    #   - --max-http-header-size flag (for node, see package.json)
+    #   - nginx.conf (in /ui)
+    client_header_buffer_size 64k;
+    large_client_header_buffers 4 64k;
+
     # Don't tell everyone we're running nginx, security through obscurity and
     # all that
     server_tokens off;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -24,7 +24,7 @@ http {
     # Header size (set in sync with the S2 webapp)
     #   Needs to match the following:
     #   - --max-http-header-size flag (for node, see package.json)
-    #   - nginx.ingress.kubernetes.io/configuration-snippet (see .skiff/webapp.jsonnet)
+    #   - nginx.conf (in /ingress)
     client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -21,6 +21,12 @@ http {
 
     gzip  on;
 
+    # Header size (set in sync with the S2 webapp)
+    #   Needs to match the following:
+    #   - --max-http-header-size flag (for node, see package.json)
+    client_header_buffer_size 64k;
+    large_client_header_buffers 4 64k;
+
     # Don't tell everyone we're running nginx, security through obscurity and
     # all that
     server_tokens off;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -25,7 +25,6 @@ http {
     #   Needs to match the following:
     #   - --max-http-header-size flag (for node, see package.json)
     #   - nginx.conf (in /ingress)
-    client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
 
     # Don't tell everyone we're running nginx, security through obscurity and

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -24,6 +24,7 @@ http {
     # Header size (set in sync with the S2 webapp)
     #   Needs to match the following:
     #   - --max-http-header-size flag (for node, see package.json)
+    #   - nginx.ingress.kubernetes.io/configuration-snippet (see .skiff/webapp.jsonnet)
     client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
 


### PR DESCRIPTION
Ref https://github.com/allenai/scholar/issues/24644

S2 (primarily for internal users) can use very large cookies, which often exceed default header size limits. This is a follow-up to https://github.com/allenai/scholarphi/pull/153 that increases the nginx limit to match the limit used by the API server (and, also, S2)