### PR TITLE
Run ScholarPhi against S2 managed database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ yarn-error.log*
 
 # pycharm
 .idea
+.python-version

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,10 +7,7 @@ nconf
   .file({ file: process.env.SECRETS_FILE || "config/secret.json" })
   .defaults({
     database: {
-      host: "scholarphi-db-prod.cluster-civm9kvdku8h.us-west-2.rds.amazonaws.com",
       port: 5432,
-      database: "scholarphi",
-      user: "api",
       schema: "public",
     },
   });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,9 +7,9 @@ nconf
   .file({ file: process.env.SECRETS_FILE || "config/secret.json" })
   .defaults({
     database: {
-      host: "scholar-reader.c5tvjmptvzlz.us-west-2.rds.amazonaws.com",
+      host: "scholarphi-db-prod.cluster-civm9kvdku8h.us-west-2.rds.amazonaws.com",
       port: 5432,
-      database: "scholar-reader",
+      database: "scholarphi",
       user: "api",
       schema: "public",
     },

--- a/data-processing/common/commands/database.py
+++ b/data-processing/common/commands/database.py
@@ -14,7 +14,7 @@ class DatabaseUploadCommand(ArxivBatchCommand[I, R], ABC):
 
     def __init__(self, args: Any) -> None:
         super().__init__(args)
-        init_database_connections(schema_name=args.schema, create_tables=True)
+        init_database_connections(schema_name=args.schema, create_tables=False)
 
     @staticmethod
     def init_parser(parser: ArgumentParser) -> None:

--- a/data-processing/common/commands/database.py
+++ b/data-processing/common/commands/database.py
@@ -14,7 +14,9 @@ class DatabaseUploadCommand(ArxivBatchCommand[I, R], ABC):
 
     def __init__(self, args: Any) -> None:
         super().__init__(args)
-        init_database_connections(schema_name=args.schema, create_tables=False)
+        init_database_connections(
+            schema_name=args.schema, create_tables=args.create_tables
+        )
 
     @staticmethod
     def init_parser(parser: ArgumentParser) -> None:

--- a/data-processing/config.ini
+++ b/data-processing/config.ini
@@ -47,11 +47,11 @@ port = <input-port>
 # Credentials for uploading data processing results to the database. Contact a
 # project administrator for the complete credentials.
 [output-db]
-db_name = scholar-reader
-user = data-pipeline
+db_name = %(READER_DB_NAME)s
+user = %(READER_DB_USER)s
 password = %(READER_DB_PASSWORD)s
-host = scholar-reader.c5tvjmptvzlz.us-west-2.rds.amazonaws.com
-port = 5432
+host = %(READER_DB_HOST)s
+port = %(READER_DB_PORT)s
 
 # Credentials for ScholarPhi bot for sending an email digest of processing results. Contact a
 # project administrator for the complete credentials.

--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -58,6 +58,7 @@ def run_commands_for_arxiv_ids(
         command_args.batch_size = pipeline_args.entity_batch_size
         command_args.log_names = [log_filename]
         command_args.schema = pipeline_args.database_schema
+        command_args.create_tables = pipeline_args.database_create_tables
         command_args.data_version = pipeline_args.data_version
         if CommandCls == FetchArxivSources:
             command_args.s3_bucket = pipeline_args.s3_arxiv_sources_bucket
@@ -287,6 +288,14 @@ if __name__ == "__main__":
             + "follow the naming rules for Postgres identifiers "
             + "(see https://www.postgresql.org/docs/9.2/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)."
         ),
+    )
+    parser.add_argument(
+        "--database-create-tables",
+        type=bool,
+        default=False,
+        help="""
+        When True (default False) try to create a database schema (requires running as admin DB user)
+        """,
     )
     parser.add_argument(
         "--data-version",

--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -291,10 +291,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--database-create-tables",
-        type=bool,
         default=False,
+        action="store_true",
         help="""
-        When True (default False) try to create a database schema (requires running as admin DB user)
+        When provied as flag try to create a database schema (requires running as admin DB user)
         """,
     )
     parser.add_argument(

--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -37,7 +37,9 @@ from scripts.process import (
 
 
 def run_commands_for_arxiv_ids(
-    CommandClasses: CommandList, arxiv_id_list: List[str], pipeline_args: Namespace,
+    CommandClasses: CommandList,
+    arxiv_id_list: List[str],
+    pipeline_args: Namespace,
 ) -> PipelineDigest:
     " Run a sequence of pipeline commands for a list of arXiv IDs. "
 
@@ -426,15 +428,17 @@ if __name__ == "__main__":
     pipeline_digest: PipelineDigest = {}
     if args.one_paper_at_a_time:
         for arxiv_id in arxiv_ids:
-            logging.info("Running pipeline for paper %s", arxiv_id)
-            digest_for_paper = run_commands_for_arxiv_ids(
-                filtered_commands, [arxiv_id], args
-            )
-            # The pipeline digest must be updated after each arXiv ID is processed, because the
-            # digest for a paper cannot be computed once the paper's data is deleted.
-            pipeline_digest.update(digest_for_paper)
-            if not args.keep_data:
-                file_utils.delete_data(arxiv_id)
+            try:
+                logging.info("Running pipeline for paper %s", arxiv_id)
+                digest_for_paper = run_commands_for_arxiv_ids(
+                    filtered_commands, [arxiv_id], args
+                )
+                # The pipeline digest must be updated after each arXiv ID is processed, because the
+                # digest for a paper cannot be computed once the paper's data is deleted.
+                pipeline_digest.update(digest_for_paper)
+            finally:
+                if not args.keep_data:
+                    file_utils.delete_data(arxiv_id)
     else:
         logging.info("Running pipeline for papers %s", arxiv_ids)
         digest_for_papers = run_commands_for_arxiv_ids(

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10190,8 +10190,8 @@
           "from": "git://github.com/mathjax/MathJax-src.git",
           "requires": {
             "esm": "^3.2.25",
-            "mj-context-menu": "^0.2.0",
-            "speech-rule-engine": "^3.0.0-beta.6"
+            "mj-context-menu": "^0.6.1",
+            "speech-rule-engine": "^3.1.1"
           }
         },
         "mj-context-menu": {
@@ -10216,7 +10216,6 @@
       "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.0.0.tgz",
       "integrity": "sha512-DvTUi2WvrACXZRjjzS0EbXY2ssRD23yuSMHVYZNbRuCA5zFZvu0MZWFy8QRvNYwJ44hJirJCNOCii0W0Q1R62A==",
       "requires": {
-        "dompurify": "^2.0.7",
         "esm": "^3.2.25",
         "mj-context-menu": "^0.2.0",
         "speech-rule-engine": "^3.0.0-beta.6"


### PR DESCRIPTION
Gathers changes to run ScholarPhi against S2 database:

1. Move all DB parameters to environment variables
2. Clean-up with try/finally when `--one-paper-at-a-time`
3. Change DB name to 'scholarphi' and use public schema as we have different DB instances for dev vs. prod

This cannot be merged yet b/c the production Skiff application probably cannot reach the DB instances in the private network (AI2 inf VPC).