### PR TITLE
Accept the `X-Forwarded-For` header from all clients.

### DIFF
--- a/ingress/nginx.conf
+++ b/ingress/nginx.conf
@@ -9,12 +9,7 @@ events {
 }
 
 http {
-    # Accept `X-Forwarded-For` from local clients (other things running
-    # on the Kubernetes cluster, and on our internal network). This ensures
-    # the server can resolve the correct IP address of the actual client, rather
-    # than that of the ingress controller.
-    set_real_ip_from    10.0.0.0/8;
-    set_real_ip_from    172.16.0.0/12;
+    set_real_ip_from    0.0.0.0/0;
     real_ip_header      X-Forwarded-For;
 
     include       /etc/nginx/mime.types;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -49,7 +49,7 @@ http {
     '}';
 
     server {
-        # We listen on 4000, as we run a reverse proxy on 80 that forward
+        # We listen on 4000, as we run a reverse proxy on 80 that forwards
         # traffic to this server.
         listen [::]:4000;
         listen 4000;


### PR DESCRIPTION
Services on the cluster (like ScholarPhi) are only accessible
on the cluster. This means we can simply access the `X-Forwarded-For`
header from all clients.

We patched this awhile back in the [template](https://github.com/allenai/skiff-template/blob/master/proxy/nginx.conf#L14),
I figured I'd port that over to ScholarPhi too.