### PR TITLE
Update node to patch a CVE.

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.0-alpine AS build
+FROM node:14.15.1-alpine3.12 AS build
 
 WORKDIR /app
 
@@ -17,8 +17,8 @@ RUN npm run build
 
 # We use what's called a "multi stage" build to reduce the size of the final
 # image. This allows us to ditch the dependencies and other build time stuff
-# we need to build the image, but don't need at runtime.
-FROM node:12.13.0-alpine AS runtime
+# that aren't needed at runtime.
+FROM node:14.15.1-alpine3.12 AS runtime
 
 WORKDIR /app
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1-alpine3.12 AS build
+FROM node:12.20.0-alpine3.12 AS build
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN npm run build
 # We use what's called a "multi stage" build to reduce the size of the final
 # image. This allows us to ditch the dependencies and other build time stuff
 # that aren't needed at runtime.
-FROM node:14.15.1-alpine3.12 AS runtime
+FROM node:12.20.0-alpine3.12 AS runtime
 
 WORKDIR /app
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1 as build
+FROM node:12.20.0 as build
 WORKDIR /ui
 
 # Install dependencies

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.0 as build
+FROM node:14.15.1 as build
 WORKDIR /ui
 
 # Install dependencies


### PR DESCRIPTION
NodeJS distributed a patch for a high severity CVE, see:
https://twitter.com/nodejs/status/1328723765157617672?s=21

I chose to bump the `node` version to `14` from `12` here because
`14` is the latest LTS release, so it seemed like a good thing
to do. Everything appeared to work, though admittedly my
testing only went as far as:

```
cd api/
docker run --rm -it 3000:3000 $(docker build -q .)
curl http://localhost:3000/health

cd ../ui
docker run --rm -it 4000:4000 $(docker build -q .)
open http://localhost:4000/?file=https://arxiv.org/pdf/0801.4750.pdf
```

Everything appeared to work. If more thorough testing is warranged
let me know (and ideally point me at instructions for doing so).

Here's the relevant ticket:
https://github.com/allenai/reviz/issues/155

Oh, and @mjlangan this CVE might be worth letting S2 proper know
about too, provided y'all still run a node service in production (I know
I left at least one lyinng around, though I'm pretty sure it got deprecated).