### PR TITLE
Update the health route so it's public.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -169,12 +169,7 @@ function(
                             image: apiImage,
                             readinessProbe: {
                                 httpGet: apiHealthCheck + {
-                                    path: '/health?check=rdy'
-                                }
-                            },
-                            livenessProbe: {
-                                httpGet: apiHealthCheck + {
-                                    path: '/health?check=rdy'
+                                    path: '/api/health'
                                 }
                             },
                             resources: {
@@ -205,11 +200,6 @@ function(
                                     path: '/?check=rdy'
                                 }
                             },
-                            livenessProbe: {
-                                httpGet: uiHealthCheck + {
-                                    path: '/?check=live'
-                                }
-                            },
                             resources: {
                                 requests: {
                                    cpu: '0.2',
@@ -223,11 +213,6 @@ function(
                             readinessProbe: {
                                 httpGet: ingressHealthCheck + {
                                     path: '/?check=rdy'
-                                }
-                            },
-                            livenessProbe: {
-                                httpGet: ingressHealthCheck + {
-                                    path: '/?check=live'
                                 }
                             },
                             resources: {

--- a/api/README.md
+++ b/api/README.md
@@ -21,7 +21,7 @@ npm start
 To check that the server is running, call:
 
 ```bash
-curl 0.0.0.0:3000/health
+curl 0.0.0.0:3000/api/health
 ```
 
 And you should see a response of 👍.

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -49,7 +49,7 @@ class ApiServer {
       },
     });
 
-    this._server.route({ method: "GET", path: "/health", handler: () => "👍" });
+    this._server.route({ method: "GET", path: "/api/health", handler: () => "👍" });
 
     this._server.route({
       method: "POST",

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -46,10 +46,10 @@ describe("API", () => {
     await server.destroy();
   });
 
-  test("GET /health", async () => {
+  test("GET /api/health", async () => {
     const response = await server.inject({
       method: "get",
-      url: "/health",
+      url: "/api/health",
     });
     expect(response.statusCode).toEqual(200);
   });


### PR DESCRIPTION
This way we can use an uptime check to verify that the API is
healthy.

I removed the `livenessProbe`s, as it's something we've learned
shouldn't be used unless it's necessary.  These probes cause the
pod to be restarted when they start failing. It sounds nice in practice,
but if your server gets overwhelmed you want to give it time to
play catch-up, so that the requests being processed by the pod aren't
dropped on the floor.  The hard-restart behavior is only necessary
for pathological processes with errant behavior, like memory leaks.