### PR TITLE
Upload symbol definitions so they can be seen in ScholarPhi interface

### DIFF
--- a/data-processing/common/colorize_tex.py
+++ b/data-processing/common/colorize_tex.py
@@ -2,12 +2,12 @@ import colorsys
 import logging
 import os
 from dataclasses import dataclass
-from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple
 
 import numpy as np
 
 from common.parse_tex import BeginDocumentExtractor, DocumentclassExtractor, overlaps
-from common.types import CharacterRange, Hue, SerializableEntity
+from common.types import CharacterRange, ColorizeOptions, Hue, SerializableEntity
 
 """
 Most TeX coloring operations follow the same process.
@@ -164,50 +164,6 @@ def _get_color_end_tex(entity_id: str) -> str:
     were successfully colorized before errors were encountered.
     """
     return rf"\scholarrevertcolor{{}}\message{{S2: Colorized entity '{entity_id}'.}}"
-
-
-ColorWhenFunc = Callable[[SerializableEntity], bool]
-GroupEntitiesFunc = Callable[[List[SerializableEntity]], List[List[SerializableEntity]]]
-ColorPositionsFunc = Callable[[SerializableEntity], CharacterRange]
-
-
-@dataclass(frozen=True)
-class ColorizeOptions:
-    """
-    Options to alter the behavior of the 'colorize_entities' function.
-    """
-
-    insert_color_macros: bool = True
-    """
-    Whether to insert definitions of color macros at the top of each file in which
-    entities are colorized. One reason to set this value to 'False' is when testing
-    the 'colorize_text' method
-    """
-
-    preset_hue: Optional[float] = None
-    " If defined, all entities will be colored this single hue. "
-
-    when: Optional[ColorWhenFunc] = None
-    " Filter that decides whether to color a particular entity. "
-
-    group: Optional[GroupEntitiesFunc] = None
-    """
-    Callback to split entities in groups that will be colorized independently. Define this,
-    for instance, to ensure that overlapping entities (e.g., symbols and their subsymbols)
-    aren't colorized in the same batch.
-    """
-
-    adjust_color_positions: Optional[ColorPositionsFunc] = None
-    """
-    Callback that maps an entity to a range of characters that should be colorized in a TeX file.
-    If not defined, the range of characters that will be colored will be the span of the entity.
-    """
-
-    braces: bool = False
-    """
-    Whether to surround the colorized entity in curly braces. This seems to be important for
-    preventing compilation errors for certaint types of entities, like equation tokens.
-    """
 
 
 EntityId = str

--- a/data-processing/common/commands/locate_entities.py
+++ b/data-processing/common/commands/locate_entities.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Deque, Dict, Iterator, List, Optional, Type
 
 from common import directories, file_utils
-from common.colorize_tex import ColorizedTex, ColorizeOptions, colorize_entities
+from common.colorize_tex import ColorizedTex, colorize_entities
 from common.commands.base import ArxivBatchCommand
 from common.commands.compile_tex import save_compilation_result
 from common.commands.raster_pages import raster_pages
@@ -24,6 +24,7 @@ from common.locate_entities import locate_entities
 from common.types import (
     ArxivId,
     ColorizationRecord,
+    ColorizeOptions,
     FileContents,
     HueLocationInfo,
     RelativePath,
@@ -101,8 +102,8 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
     @abstractmethod
     def get_entity_name() -> str:
         """
-        Get the name of the type of entity that will be batch processed in these commands.
-        This command will be used to determine the names of output directories.
+        Get the name of the type of entity that will be batch processed in this command.
+        This name will be used to determine the names of output directories.
         """
 
     def get_arxiv_ids_dirkey(self) -> str:

--- a/data-processing/common/commands/normalize_tex.py
+++ b/data-processing/common/commands/normalize_tex.py
@@ -40,6 +40,15 @@ class NormalizeTexSources(ArxivBatchCommand[NormalizationTask, None]):
 
     def load(self) -> Iterator[NormalizationTask]:
         for arxiv_id in self.arxiv_ids:
+            sources_dir = directories.arxiv_subdir("sources", arxiv_id)
+            if not os.path.exists(sources_dir):
+                logging.warning(  # pylint: disable=logging-not-lazy
+                    "No directory of TeX sources could be found for paper %s. The TeX for "
+                    + "this paper will not be normalized.",
+                    arxiv_id,
+                )
+                continue
+
             output_dir = directories.arxiv_subdir("normalized-sources", arxiv_id)
             if os.path.exists(output_dir):
                 logging.warning(
@@ -47,6 +56,7 @@ class NormalizeTexSources(ArxivBatchCommand[NormalizationTask, None]):
                     output_dir,
                 )
                 shutil.rmtree(output_dir)
+
             shutil.copytree(directories.arxiv_subdir("sources", arxiv_id), output_dir)
 
             compiled_tex_dir = directories.arxiv_subdir("compiled-sources", arxiv_id)

--- a/data-processing/common/commands/upload_entities.py
+++ b/data-processing/common/commands/upload_entities.py
@@ -7,7 +7,8 @@ from typing import Dict, Iterator, List, Optional, Type, Union
 from common import directories, file_utils
 from common.commands.database import DatabaseUploadCommand
 from common.types import (
-    EntityAndLocation,
+    Context,
+    EntityExtractionResult,
     EntityLocationInfo,
     EntityUploadCallable,
     PaperProcessingResult,
@@ -16,16 +17,13 @@ from common.types import (
 
 
 class UploadEntitiesCommand(DatabaseUploadCommand[PaperProcessingResult, None]):
+    @staticmethod
     @abstractmethod
-    def get_detected_entities_dirkey(self) -> str:
+    def get_entity_name() -> str:
         """
-        Key for the data directory containing a list of detected entities.
-        """
-
-    @abstractmethod
-    def get_hue_locations_dirkey(self) -> str:
-        """
-        Key for the data directory containing hue locations for entities.
+        Get the name of the type of entity that will be processed in this command. This name will
+        be used to determine the names of input directories to read, and output directories to
+        write to.
         """
 
     @staticmethod
@@ -56,7 +54,7 @@ class UploadEntitiesCommand(DatabaseUploadCommand[PaperProcessingResult, None]):
             # might be saved in multiple files. If they are, for this upload function to work,
             # each of the entities need to have a unique pair of 'ID' and 'tex_path'.
             entities_dir = directories.arxiv_subdir(
-                self.get_detected_entities_dirkey(), arxiv_id
+                f"detected-{self.get_entity_name()}", arxiv_id
             )
             entities: List[SerializableEntity] = []
             for entities_path in glob.glob(os.path.join(entities_dir, "entities*.csv")):
@@ -67,12 +65,14 @@ class UploadEntitiesCommand(DatabaseUploadCommand[PaperProcessingResult, None]):
                     )
                 )
 
-            # Load in locations of all detected hues.
-            hue_locations_path = os.path.join(
-                directories.arxiv_subdir(self.get_hue_locations_dirkey(), arxiv_id),
+            # Load locations for entities.
+            locations_path = os.path.join(
+                directories.arxiv_subdir(
+                    f"{self.get_entity_name()}-locations", arxiv_id
+                ),
                 "entity_locations.csv",
             )
-            if not os.path.exists(hue_locations_path):
+            if not os.path.exists(locations_path):
                 logging.warning(  # pylint: disable=logging-not-lazy
                     "No locations have been saved for entities in command '%s' for paper %s. No entities "
                     + "will be uploaded for this paper.",
@@ -80,24 +80,50 @@ class UploadEntitiesCommand(DatabaseUploadCommand[PaperProcessingResult, None]):
                     arxiv_id,
                 )
                 continue
-
             entity_location_infos = list(
-                file_utils.load_from_csv(hue_locations_path, EntityLocationInfo)
+                file_utils.load_from_csv(locations_path, EntityLocationInfo)
             )
 
-            # Group each entity with its location. Pass the entity information, and the detected
-            # locations for the entity, to the upload function.
-            localized_enitites = []
+            # Load in contexts for all entities.
+            contexts_loaded = False
+            contexts_by_entity = {}
+            if directories.registered(f"contexts-for-{self.get_entity_name()}"):
+                contexts_path = os.path.join(
+                    directories.arxiv_subdir(
+                        f"contexts-for-{self.get_entity_name()}", arxiv_id
+                    ),
+                    "contexts.csv",
+                )
+                if os.path.exists(contexts_path):
+                    contexts = file_utils.load_from_csv(contexts_path, Context)
+                    contexts_by_entity = {c.entity_id: c for c in contexts}
+                    contexts_loaded = True
+
+            if not contexts_loaded:
+                logging.warning(  # pylint: disable=logging-not-lazy
+                    "No contexts have been saved for entities in command '%s' for paper %s. No "
+                    + "contexts will be saved for any of these entities.",
+                    str(self.get_name()),
+                    arxiv_id,
+                )
+
+            # Group each entity with its location and context. Then pass all entity information to
+            # the upload function.
+            entity_summaries = []
             for entity in entities:
                 matching_locations = []
                 for h in entity_location_infos:
                     if h.entity_id == entity.id_ and h.tex_path == entity.tex_path:
                         matching_locations.append(h)
 
-                localized_enitites.append(EntityAndLocation(entity, matching_locations))
+                entity_summaries.append(
+                    EntityExtractionResult(
+                        entity, matching_locations, contexts_by_entity.get(entity.id_)
+                    )
+                )
 
             yield PaperProcessingResult(
-                arxiv_id=arxiv_id, s2_id=s2_id, localized_entities=localized_enitites,
+                arxiv_id=arxiv_id, s2_id=s2_id, entities=entity_summaries,
             )
 
     def process(self, _: PaperProcessingResult) -> Iterator[None]:
@@ -137,7 +163,7 @@ def make_upload_entities_command(
             return f"Upload {entity_name} and their locations to the database."
 
         def get_arxiv_ids_dirkey(self) -> str:
-            return self.get_hue_locations_dirkey()
+            return f"{entity_name}-locations"
 
         @staticmethod
         def get_detected_entity_type(
@@ -158,11 +184,9 @@ def make_upload_entities_command(
                     return super(C, C).get_detected_entity_type(entity_filename)
             return DetectedEntityType
 
-        def get_detected_entities_dirkey(self) -> str:
-            return f"detected-{entity_name}"
-
-        def get_hue_locations_dirkey(self) -> str:
-            return f"{entity_name}-locations"
+        @staticmethod
+        def get_entity_name() -> str:
+            return entity_name
 
         def save(self, item: PaperProcessingResult, _: None) -> None:
             upload_func(item, self.args.data_version)

--- a/data-processing/common/compile.py
+++ b/data-processing/common/compile.py
@@ -201,6 +201,8 @@ def _get_compilation_results_dir(compiled_tex_dir: RelativePath) -> RelativePath
 
 def _did_compilation_succeed(compiled_tex_dir: RelativePath) -> bool:
     result_path = os.path.join(_get_compilation_results_dir(compiled_tex_dir), "result")
+    if not os.path.exists(result_path):
+        return False
     with open(result_path) as result_file:
         result = result_file.read().strip()
         return result == "True"
@@ -235,7 +237,7 @@ def get_compiled_tex_files(compiled_tex_dir: RelativePath) -> List[CompiledTexFi
         if not os.path.exists(compiled_tex_files_path):
             logging.warning(  # pylint: disable=logging-not-lazy
                 "Although compilation succeeded for TeX compilation in directory %s, no "
-                + "no specific TeX files were logged as having been compiled. Something "
+                + "specific TeX files were logged as having been compiled. Something "
                 + "unexpected must have happened during compilation of the TeX.",
                 compiled_tex_dir,
             )

--- a/data-processing/common/compile.py
+++ b/data-processing/common/compile.py
@@ -107,7 +107,7 @@ def get_compiled_tex_files_from_autotex_output(
     return [
         CompiledTexFile(filename.decode("utf-8"))
         for filename in processed_tex_files
-        if filename not in failed_tex_files
+        if filename not in failed_tex_files and not filename.endswith(b".dvi")
     ]
 
 
@@ -232,6 +232,14 @@ def get_compiled_tex_files(compiled_tex_dir: RelativePath) -> List[CompiledTexFi
         compiled_tex_files_path = os.path.join(
             _get_compilation_results_dir(compiled_tex_dir), "compiled_tex_files.csv"
         )
+        if not os.path.exists(compiled_tex_files_path):
+            logging.warning(  # pylint: disable=logging-not-lazy
+                "Although compilation succeeded for TeX compilation in directory %s, no "
+                + "no specific TeX files were logged as having been compiled. Something "
+                + "unexpected must have happened during compilation of the TeX.",
+                compiled_tex_dir,
+            )
+            return []
         compiled_tex_files = list(
             file_utils.load_from_csv(compiled_tex_files_path, CompiledTexFile)
         )

--- a/data-processing/common/file_utils.py
+++ b/data-processing/common/file_utils.py
@@ -15,26 +15,12 @@ from typing import Any, Dict, Iterator, List, Optional, Type, TypeVar
 
 from common import directories
 from common.string import JournaledString
-from common.types import (
-    ArxivId,
-    BoundingBox,
-    CompilationResult,
-    Equation,
-    EquationId,
-    FileContents,
-    HueIteration,
-    HueLocationInfo,
-    Path,
-    SerializableChild,
-    SerializableSymbol,
-    SerializableSymbolToken,
-    SerializableToken,
-    Symbol,
-    SymbolId,
-    SymbolWithId,
-    Token,
-    TokenId,
-)
+from common.types import (ArxivId, BoundingBox, CompilationResult, Equation,
+                          EquationId, FileContents, HueIteration,
+                          HueLocationInfo, Path, SerializableChild,
+                          SerializableSymbol, SerializableSymbolToken,
+                          SerializableToken, Symbol, SymbolId, SymbolWithId,
+                          Token, TokenId)
 
 Contents = str
 Encoding = str
@@ -380,6 +366,9 @@ def load_symbols(arxiv_id: ArxivId) -> Optional[List[SymbolWithId]]:
     for s in loaded_symbols:
         symbol_id = SymbolId(s.tex_path, s.equation_index, s.symbol_index)
         symbols_by_id[symbol_id] = Symbol(
+            tex_path=s.tex_path,
+            equation_index=s.equation_index,
+            symbol_index=s.symbol_index,
             tokens=[],
             start=s.start,
             end=s.end,

--- a/data-processing/common/file_utils.py
+++ b/data-processing/common/file_utils.py
@@ -15,12 +15,26 @@ from typing import Any, Dict, Iterator, List, Optional, Type, TypeVar
 
 from common import directories
 from common.string import JournaledString
-from common.types import (ArxivId, BoundingBox, CompilationResult, Equation,
-                          EquationId, FileContents, HueIteration,
-                          HueLocationInfo, Path, SerializableChild,
-                          SerializableSymbol, SerializableSymbolToken,
-                          SerializableToken, Symbol, SymbolId, SymbolWithId,
-                          Token, TokenId)
+from common.types import (
+    ArxivId,
+    BoundingBox,
+    CompilationResult,
+    Equation,
+    EquationId,
+    FileContents,
+    HueIteration,
+    HueLocationInfo,
+    Path,
+    SerializableChild,
+    SerializableSymbol,
+    SerializableSymbolToken,
+    SerializableToken,
+    Symbol,
+    SymbolId,
+    SymbolWithId,
+    Token,
+    TokenId,
+)
 
 Contents = str
 Encoding = str
@@ -141,7 +155,25 @@ def load_from_csv(
     """
     with open(csv_path, encoding=encoding, newline="") as csv_file:
         reader = csv.DictReader(csv_file, quoting=csv.QUOTE_MINIMAL)
-        for row in reader:
+
+        while True:
+            try:
+                row = next(reader)
+            except csv.Error as e:
+                # One type of error that may occur is the data being larger than the CSV field size
+                # (see https://stackoverflow.com/questions/15063936).
+                # Rather than increasing the field size limit, this code skips those rows, as this
+                # does not require anticipation of the maximum size that data for a row can be.
+                logging.warning(  # pylint: disable=logging-not-lazy
+                    "Could not load row from CSV file %s. Error: %s. The rest of this file "
+                    + "will be skipped as the CSV reader has lost its place.",
+                    csv_path,
+                    e,
+                )
+                break
+            except StopIteration:
+                break
+
             data: Dict[str, Any] = {}
             # Transfer data from the row into a dictionary of arguments. By only including the
             # fields for D, we skip over columns that can't be used to initialize D. At the

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -540,7 +540,7 @@ def _is_affix_token(element: Tag) -> bool:
     return (
         bool(parent.name == "mover")
         and bool(element.find_previous("mi"))
-        and (parent.attrs["accent"] == "true")
+        and (parent.attrs.get("accent") == "true")
     )
 
 

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -657,6 +657,10 @@ class EntityUploadInfo:
     bounding_boxes: List[BoundingBox]
     data: Optional[EntityData] = None
     relationships: Optional[EntityRelationships] = None
+    """
+    Mappings from this entity to other entities it's related to. For example, this could contain
+    lists of IDs of other sentences where the entity appears.
+    """
 
 
 VersionNumber = int

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -314,6 +314,9 @@ MathML = str
 
 @dataclass
 class Symbol:
+    tex_path: str
+    equation_index: int
+    symbol_index: int
     tokens: List[Token]
     tex: str
     start: int

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -401,10 +401,54 @@ class SerializableSymbolToken(SymbolId, TokenId):
 
 
 """
-COLORIZATION RECORDS
+COLORIZATION
 """
 
 Hue = float
+
+
+ColorWhenFunc = Callable[[SerializableEntity], bool]
+GroupEntitiesFunc = Callable[[List[SerializableEntity]], List[List[SerializableEntity]]]
+ColorPositionsFunc = Callable[[SerializableEntity], CharacterRange]
+
+
+@dataclass(frozen=True)
+class ColorizeOptions:
+    """
+    Options to alter the behavior of the 'colorize_entities' function.
+    """
+
+    insert_color_macros: bool = True
+    """
+    Whether to insert definitions of color macros at the top of each file in which
+    entities are colorized. One reason to set this value to 'False' is when testing
+    the 'colorize_text' method
+    """
+
+    preset_hue: Optional[float] = None
+    " If defined, all entities will be colored this single hue. "
+
+    when: Optional[ColorWhenFunc] = None
+    " Filter that decides whether to color a particular entity. "
+
+    group: Optional[GroupEntitiesFunc] = None
+    """
+    Callback to split entities in groups that will be colorized independently. Define this,
+    for instance, to ensure that overlapping entities (e.g., symbols and their subsymbols)
+    aren't colorized in the same batch.
+    """
+
+    adjust_color_positions: Optional[ColorPositionsFunc] = None
+    """
+    Callback that maps an entity to a range of characters that should be colorized in a TeX file.
+    If not defined, the range of characters that will be colored will be the span of the entity.
+    """
+
+    braces: bool = False
+    """
+    Whether to surround the colorized entity in curly braces. This seems to be important for
+    preventing compilation errors for certaint types of entities, like equation tokens.
+    """
 
 
 @dataclass(frozen=True)
@@ -539,6 +583,45 @@ DATABASE UPLOADS
 
 
 @dataclass(frozen=True)
+class Context:
+    " A context that an entity appears in within a paper. "
+    tex_path: str
+    entity_id: str
+    " Together, 'tex_path' and 'entity_id' specify the entity that the context is for. "
+
+    sentence_id: str
+    " ID of the sentence that the entity appears in. "
+
+    snippet: str
+    """
+    A snippet of human-readable text optimized to show the entity in context. This may include HTML
+    or LaTeX, depending on the context the snippet is meant to appear in.
+    """
+
+    neighbor_entity_ids: List[str]
+    """
+    A list of entity IDs for entities of the same type that also appear in the same sentence. For
+    example, this could include IDs of other symbols of the same name in the same sentence.
+    """
+
+
+@dataclass(frozen=True)
+class EntityExtractionResult:
+    " An aggregate class containing information for an entity extracted from the pipeline. "
+    entity: SerializableEntity
+    locations: List[EntityLocationInfo]
+    context: Optional[Context] = None
+
+
+@dataclass(frozen=True)
+class PaperProcessingResult:
+    " Contains information about all entities processed for a paper. "
+    arxiv_id: ArxivId
+    s2_id: S2Id
+    entities: List[EntityExtractionResult]
+
+
+@dataclass(frozen=True)
 class EntityReference:
     """
     Reference to another entity within the same paper. The combination of entity ID and type should
@@ -564,7 +647,7 @@ EntityRelationships = Dict[str, Union[EntityReference, List[EntityReference]]]
 
 
 @dataclass(frozen=True)
-class EntityInformation:
+class EntityUploadInfo:
     id_: str
     type_: str
     " Together, the 'id' and the 'type' should provide a unique ID for this entity within the paper. "
@@ -572,19 +655,6 @@ class EntityInformation:
     bounding_boxes: List[BoundingBox]
     data: Optional[EntityData] = None
     relationships: Optional[EntityRelationships] = None
-
-
-@dataclass(frozen=True)
-class EntityAndLocation:
-    entity: SerializableEntity
-    locations: List[EntityLocationInfo]
-
-
-@dataclass(frozen=True)
-class PaperProcessingResult:
-    arxiv_id: ArxivId
-    s2_id: S2Id
-    localized_entities: List[EntityAndLocation]
 
 
 VersionNumber = int

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -225,7 +225,6 @@ class Phrase(SerializableEntity):
 @dataclass(frozen=True)
 class Term(SerializableEntity):
     text: str
-    sentence_id: Optional[str]
 
     type_: Optional[str]
     " Type of term (e.g., symbol, protologism, abbreviation). "

--- a/data-processing/common/upload_entities.py
+++ b/data-processing/common/upload_entities.py
@@ -209,6 +209,13 @@ def make_data_models(
                 type_ = "float"
             elif isinstance(v, str):
                 type_ = "string"
+            else:
+                logging.debug(  # pylint: disable=logging-not-lazy
+                    "When create a row of entity data, a primitive type could not be "
+                    + "determined for a value with the key '%s'. Make sure that all "
+                    + "entity data is either a primitive type or a list of primitive types. "
+                    + "No row will be created for this data value."
+                )
 
             if type_ is not None:
                 if entity_model is not None:

--- a/data-processing/common/upload_entities.py
+++ b/data-processing/common/upload_entities.py
@@ -7,7 +7,7 @@ from common.models import BoundingBox as BoundingBoxModel
 from common.models import Entity
 from common.models import EntityData as EntityDataModel
 from common.models import Paper, Version, output_database, session_id
-from common.types import ArxivId, EntityInformation, EntityReference, S2Id
+from common.types import ArxivId, EntityReference, EntityUploadInfo, S2Id
 
 
 def get_or_create_data_version(paper_id: str) -> int:
@@ -36,7 +36,7 @@ def get_or_create_data_version(paper_id: str) -> int:
 def upload_entities(
     s2_id: S2Id,
     arxiv_id: ArxivId,
-    entities: List[EntityInformation],
+    entities: List[EntityUploadInfo],
     data_version: Optional[int] = None,
 ) -> None:
     """

--- a/data-processing/entities/citations/__init__.py
+++ b/data-processing/entities/citations/__init__.py
@@ -11,7 +11,6 @@ from .commands.upload_citations import UploadCitations
 from .make_digest import make_digest
 from .types import Bibitem
 
-
 directories.register("detected-citations")
 directories.register("bibitem-resolutions")
 directories.register("sources-with-colorized-citations")
@@ -27,7 +26,7 @@ commands: CommandList = [
     ExtractBibitems,
     ResolveBibitems,
     make_locate_entities_command(
-        "citations", Bibitem, colorize_func=colorize_citations
+        "citations", DetectedEntityType=Bibitem, colorize_func=colorize_citations
     ),
     LocateCitations,
     UploadCitations,

--- a/data-processing/entities/citations/colorize.py
+++ b/data-processing/entities/citations/colorize.py
@@ -2,17 +2,18 @@ from typing import List
 
 from common.colorize_tex import (
     ColorizedTex,
-    ColorizeOptions,
-    generate_hues,
-    add_color_macros,
     _get_tex_color,
+    add_color_macros,
+    generate_hues,
 )
 from common.parse_tex import DocumentclassExtractor
-from common.types import SerializableEntity
+from common.types import ColorizeOptions, SerializableEntity
 
 
 def colorize_citations(
-    tex: str, bibitems: List[SerializableEntity], options: ColorizeOptions = ColorizeOptions()
+    tex: str,
+    bibitems: List[SerializableEntity],
+    options: ColorizeOptions = ColorizeOptions(),
 ) -> ColorizedTex:
     """
     To save time, this function only attempts to add colorization commands to the main document file,

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -9,7 +9,7 @@ from common.commands.database import DatabaseUploadCommand
 from common.types import (
     BoundingBox,
     CitationData,
-    EntityInformation,
+    EntityUploadInfo,
     SerializableReference,
 )
 from common.upload_entities import upload_entities
@@ -114,7 +114,7 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
 
             for cluster_index, location_set in locations.items():
                 boxes = cast(List[BoundingBox], list(location_set))
-                entity_info = EntityInformation(
+                entity_info = EntityUploadInfo(
                     id_=f"{citation_key}-{cluster_index}",
                     type_="citation",
                     bounding_boxes=boxes,

--- a/data-processing/entities/common.py
+++ b/data-processing/entities/common.py
@@ -1,13 +1,12 @@
 from typing import List, Optional, Type
 
 from common import directories
-from common.colorize_tex import ColorizeOptions
 from common.commands.base import Command, CommandList
 from common.commands.detect_entities import make_detect_entities_command
 from common.commands.locate_entities import ColorizeFunc, make_locate_entities_command
 from common.commands.upload_entities import make_upload_entities_command
 from common.parse_tex import EntityExtractor
-from common.types import EntityUploadCallable, SerializableEntity
+from common.types import ColorizeOptions, EntityUploadCallable, SerializableEntity
 from entities.sentences.commands.extract_contexts import make_extract_contexts_command
 from entities.sentences.types import TexWrapper
 

--- a/data-processing/entities/common.py
+++ b/data-processing/entities/common.py
@@ -8,11 +8,14 @@ from common.commands.locate_entities import ColorizeFunc, make_locate_entities_c
 from common.commands.upload_entities import make_upload_entities_command
 from common.parse_tex import EntityExtractor
 from common.types import EntityUploadCallable, SerializableEntity
+from entities.sentences.commands.extract_contexts import make_extract_contexts_command
+from entities.sentences.types import TexWrapper
 
 
 def create_entity_localization_command_sequence(
     entity_name: str,
     EntityExtractorType: Type[EntityExtractor],
+    extract_contexts: bool = False,
     DetectedEntityType: Optional[Type[SerializableEntity]] = None,
     upload_func: Optional[EntityUploadCallable] = None,
     colorize_options: ColorizeOptions = ColorizeOptions(),
@@ -27,24 +30,32 @@ def create_entity_localization_command_sequence(
     LaTeX, raster the pages, and locate the colors in the pages. You may define additional
     paramters (e.g., 'colorize_options') to fine-tune the commands.
 
+    To extract the contexts for an entity (i.e., the sentences in which the entities appear),
+    set 'extract_contexts' to True.
+
     If you are trying to find the locations of a new type of entity, it is highly recommended that
     you use this convenience methods instead of creating new commands yourself.
     """
 
-    # Register directories for output from intermediate pipeline stages.
+    commands: CommandList = []
+
     directories.register(f"detected-{entity_name}")
+    commands.append(make_detect_entities_command(entity_name, EntityExtractorType))
+
+    if extract_contexts:
+        directories.register(f"contexts-for-{entity_name}")
+        commands.append(make_extract_contexts_command(entity_name))
+
     directories.register(f"sources-with-colorized-{entity_name}")
     directories.register(f"compiled-sources-with-colorized-{entity_name}")
     directories.register(f"paper-images-with-colorized-{entity_name}")
     directories.register(f"diffed-images-with-colorized-{entity_name}")
     directories.register(f"{entity_name}-locations")
-
-    commands: CommandList = [
-        make_detect_entities_command(entity_name, EntityExtractorType),
+    commands.append(
         make_locate_entities_command(
             entity_name, None, DetectedEntityType, colorize_options, colorize_func
-        ),
-    ]
+        )
+    )
 
     if upload_func is not None:
         upload_command = make_upload_entities_command(

--- a/data-processing/entities/definitions/commands/detect_definitions.py
+++ b/data-processing/entities/definitions/commands/detect_definitions.py
@@ -757,6 +757,7 @@ class DetectDefinitions(
                                 tex=definition_tex,
                                 text=pair.definition_text,
                                 context_tex=sentence.context_tex,
+                                sentence_id=sentence.id_,
                                 intent=bool(intent),
                                 confidence=definition_confidence,
                             )
@@ -786,6 +787,7 @@ class DetectDefinitions(
                                 tex_path=tex_path,
                                 tex=definiendum_tex,
                                 context_tex=sentence.context_tex,
+                                sentence_id=sentence.id_,
                                 # Document-level features below.
                                 position_ratio=position_ratio,
                                 position_ratios=[],
@@ -853,7 +855,9 @@ class DetectDefinitions(
                 definiendum.section_names.extend(section_names[definiendum.text])
                 yield definiendum
 
-        # Detect all other references to the defined terms.
+        # Detect all other references to the defined terms. Only detect references to textual
+        # terms and abbreviations, but not symbols. References to symbols will already be
+        # detected by another stage of the pipeline.
         term_index = 0
 
         for tex_path, file_contents in item.tex_by_file.items():

--- a/data-processing/entities/definitions/commands/detect_definitions.py
+++ b/data-processing/entities/definitions/commands/detect_definitions.py
@@ -8,9 +8,8 @@ from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Union, cast
 
 from common import directories, file_utils
 from common.commands.base import ArxivBatchCommand
-from common.parse_tex import PhraseExtractor, get_containing_entity, overlaps
-from common.types import (ArxivId, CharacterRange, FileContents,
-                          SerializableEntity)
+from common.parse_tex import PhraseExtractor, overlaps
+from common.types import ArxivId, CharacterRange, FileContents
 from tqdm import tqdm
 from typing_extensions import Literal
 
@@ -758,7 +757,6 @@ class DetectDefinitions(
                                 tex=definition_tex,
                                 text=pair.definition_text,
                                 context_tex=sentence.context_tex,
-                                sentence_id=sentence.id_,
                                 intent=bool(intent),
                                 confidence=definition_confidence,
                             )
@@ -788,7 +786,6 @@ class DetectDefinitions(
                                 tex_path=tex_path,
                                 tex=definiendum_tex,
                                 context_tex=sentence.context_tex,
-                                sentence_id=sentence.id_,
                                 # Document-level features below.
                                 position_ratio=position_ratio,
                                 position_ratios=[],
@@ -858,14 +855,10 @@ class DetectDefinitions(
 
         # Detect all other references to the defined terms.
         term_index = 0
-        sentence_entities: List[SerializableEntity] = cast(
-            List[SerializableEntity], item.sentences
-        )
 
         for tex_path, file_contents in item.tex_by_file.items():
             term_extractor = PhraseExtractor(term_phrases + abbreviations)
             for t in term_extractor.parse(tex_path, file_contents.contents):
-                term_sentence = get_containing_entity(t, sentence_entities)
 
                 # Don't save term references if they are already in the definiendums.
                 if any([overlaps(definiendum, t) for definiendum in all_definiendums]):
@@ -901,9 +894,6 @@ class DetectDefinitions(
                     tex_path=t.tex_path,
                     tex=t.tex,
                     context_tex=t.context_tex,
-                    sentence_id=term_sentence.id_
-                    if term_sentence is not None
-                    else None,
                 )
                 term_index += 1
 

--- a/data-processing/entities/definitions/commands/tokenize_sentences.py
+++ b/data-processing/entities/definitions/commands/tokenize_sentences.py
@@ -80,9 +80,7 @@ class TokenizeSentences(ArxivBatchCommand[Task, TokenizedSentence]):
                 directories.arxiv_subdir("detected-sentences", arxiv_id),
                 "entities.csv",
             )
-            try:
-                sentences = file_utils.load_from_csv(detected_sentences_path, Sentence)
-            except FileNotFoundError:
+            if not os.path.exists(detected_sentences_path):
                 logging.warning(  # pylint: disable=logging-not-lazy
                     "No sentences data found for arXiv paper %s. Try re-running the pipeline, "
                     + "this time enabling the processing of sentences. If that doesn't work, "
@@ -91,6 +89,7 @@ class TokenizeSentences(ArxivBatchCommand[Task, TokenizedSentence]):
                 )
                 continue
 
+            sentences = file_utils.load_from_csv(detected_sentences_path, Sentence)
             for sentence in sentences:
                 yield Task(arxiv_id, sentence, symbols[sentence.tex_path])
 

--- a/data-processing/entities/definitions/types.py
+++ b/data-processing/entities/definitions/types.py
@@ -103,7 +103,6 @@ class Definition(SerializableEntity):
     """
 
     text: str
-    sentence_id: str
 
     definiendum: str
     " The name of the term that this definition defines. "

--- a/data-processing/entities/definitions/types.py
+++ b/data-processing/entities/definitions/types.py
@@ -103,6 +103,7 @@ class Definition(SerializableEntity):
     """
 
     text: str
+    sentence_id: str
 
     definiendum: str
     " The name of the term that this definition defines. "
@@ -136,6 +137,8 @@ class TermReference(Term):
 @dataclass(frozen=True)
 class Definiendum(TermReference):
     " A term that appears in a definition. "
+
+    sentence_id: str
 
     definition_id: str
     " The ID for the definiens that defines this term. "

--- a/data-processing/entities/definitions/upload.py
+++ b/data-processing/entities/definitions/upload.py
@@ -92,3 +92,12 @@ def upload_term_definitions(
         processing_summary.s2_id, processing_summary.arxiv_id, term_infos, data_version,
     )
 
+
+def upload_symbol_definitions(
+    processing_summary: PaperProcessingResult, data_version: Optional[int]
+) -> None:
+
+    # Load in all symbols
+
+    # For each definition...
+    pass

--- a/data-processing/entities/definitions/upload.py
+++ b/data-processing/entities/definitions/upload.py
@@ -14,6 +14,13 @@ from .types import Definition, TermReference
 def upload_definitions(
     processing_summary: PaperProcessingResult, data_version: Optional[int]
 ) -> None:
+    upload_term_definitions(processing_summary, data_version)
+
+
+def upload_term_definitions(
+    processing_summary: PaperProcessingResult, data_version: Optional[int]
+) -> None:
+    " Upload textual terms and their definitions. "
 
     term_infos = []
     definition_infos = []
@@ -56,7 +63,7 @@ def upload_definitions(
                     "definitions": term.definitions,
                     "definition_texs": term.definition_texs,
                     "sources": term.sources,
-                    "term_type": term.type_ or "unknown"
+                    "term_type": term.type_ or "unknown",
                 },
                 relationships={
                     "sentence": EntityReference(
@@ -84,3 +91,4 @@ def upload_definitions(
     upload_entities(
         processing_summary.s2_id, processing_summary.arxiv_id, term_infos, data_version,
     )
+

--- a/data-processing/entities/definitions/upload.py
+++ b/data-processing/entities/definitions/upload.py
@@ -65,7 +65,7 @@ def upload_term_definitions(
         entity = entity_summary.entity
         context = entity_summary.context
 
-        if not (is_textual_term(entity)):
+        if not is_textual_term(entity):
             continue
 
         term = cast(TermReference, entity)

--- a/data-processing/entities/definitions/upload.py
+++ b/data-processing/entities/definitions/upload.py
@@ -1,14 +1,18 @@
-from typing import Optional, cast
+from collections import defaultdict
+from typing import Dict, List, Optional, cast
 
+from common.colorize_tex import EntityId
 from common.types import (
     BoundingBox,
-    EntityInformation,
+    Context,
     EntityReference,
+    EntityUploadInfo,
     PaperProcessingResult,
+    SerializableEntity,
 )
 from common.upload_entities import upload_entities
 
-from .types import Definition, TermReference
+from .types import Definiendum, TermReference
 
 
 def upload_definitions(
@@ -17,77 +21,103 @@ def upload_definitions(
     upload_term_definitions(processing_summary, data_version)
 
 
+TermName = str
+
+
+def is_textual_term(entity: SerializableEntity) -> bool:
+    TEXTUAL_TERM_TYPES = ["abbreviation", "term"]
+
+    if entity.id_.startswith("definiendum"):
+        definiendum = cast(Definiendum, entity)
+        return definiendum.type_ in TEXTUAL_TERM_TYPES
+    if entity.id_.startswith("term"):
+        term = cast(TermReference, entity)
+        return term.type_ in TEXTUAL_TERM_TYPES
+
+    return False
+
+
 def upload_term_definitions(
     processing_summary: PaperProcessingResult, data_version: Optional[int]
 ) -> None:
     " Upload textual terms and their definitions. "
 
+    # Group contextual snippets for each term.
     term_infos = []
-    definition_infos = []
-    for entity_and_location in processing_summary.localized_entities:
-        boxes = [cast(BoundingBox, l) for l in entity_and_location.locations]
-        entity = entity_and_location.entity
+    contexts_by_term_name: Dict[TermName, List[Context]] = defaultdict(list)
+    for entity_summary in processing_summary.entities:
+        entity = entity_summary.entity
+        context = entity_summary.context
+        if is_textual_term(entity) and context is not None:
+            contexts_by_term_name[entity.text].append(context)  # type: ignore
 
-        if entity.id_.startswith("definition"):
-            definition = cast(Definition, entity)
-            definition_info = EntityInformation(
-                id_=definition.id_,
-                type_="definition",
-                bounding_boxes=boxes,
-                data={
-                    "definiendum": definition.definiendum,
-                    "definition": definition.text,
-                    "tex": definition.tex,
-                },
-                relationships={
-                    "sentence": EntityReference(
-                        type_="sentence",
-                        id_=f"{definition.tex_path}-{definition.sentence_id}"
-                        if definition.sentence_id is not None
-                        else None,
-                    ),
-                },
+    # Construct mapping from definitions to the sentences that contain them.
+    contexts_by_definition: Dict[EntityId, Context] = {}
+    for entity_summary in processing_summary.entities:
+        entity_id = entity_summary.entity.id_
+        context = entity_summary.context
+        if (entity_id.startswith("definition")) and context is not None:
+            contexts_by_definition[entity_id] = context
+
+    # Upload information for each term.
+    for entity_summary in processing_summary.entities:
+        boxes = [cast(BoundingBox, l) for l in entity_summary.locations]
+        entity = entity_summary.entity
+        context = entity_summary.context
+
+        if not (is_textual_term(entity)):
+            continue
+
+        term = cast(TermReference, entity)
+
+        # Assemble list of snippets that include this term.
+        contexts_matching_term = contexts_by_term_name.get(term.text, [])
+        snippets = [c.snippet for c in contexts_matching_term]
+        snippet_sentences = [
+            f"{c.tex_path}-{c.sentence_id}" for c in contexts_matching_term
+        ]
+
+        # Create links to the sentences containing definitions for this term.
+        definition_sentences: List[Optional[str]] = []
+        for definition_id in term.definition_ids:
+            if definition_id not in contexts_by_definition:
+                definition_sentences.append(None)
+            definition_context = contexts_by_definition[definition_id]
+            definition_sentences.append(
+                f"{definition_context.tex_path}-{definition_context.sentence_id}"
             )
-            definition_infos.append(definition_info)
 
-        if entity.id_.startswith("definiendum") or entity.id_.startswith(
-            "term-reference"
-        ):
-            term = cast(TermReference, entity)
-            term_info = EntityInformation(
-                id_=term.id_,
-                type_="term",
-                bounding_boxes=boxes,
-                data={
-                    "name": term.text,
-                    "definitions": term.definitions,
-                    "definition_texs": term.definition_texs,
-                    "sources": term.sources,
-                    "term_type": term.type_ or "unknown",
-                },
-                relationships={
-                    "sentence": EntityReference(
-                        type_="sentence",
-                        id_=f"{term.tex_path}-{term.sentence_id}"
-                        if term.sentence_id is not None
-                        else None,
-                    ),
-                    "definitions": [
-                        EntityReference(type_="definition", id_=d)
-                        for d in term.definition_ids
-                    ],
-                },
-            )
-            term_infos.append(term_info)
+        term_info = EntityUploadInfo(
+            id_=term.id_,
+            type_="term",
+            bounding_boxes=boxes,
+            data={
+                "name": term.text,
+                "term_type": term.type_ or "unknown",
+                "definitions": term.definitions,
+                "definition_texs": term.definition_texs,
+                "sources": term.sources,
+                "snippets": snippets,
+            },
+            relationships={
+                "sentence": EntityReference(
+                    type_="sentence",
+                    id_=f"{context.tex_path}-{context.sentence_id}"
+                    if context is not None
+                    else None,
+                ),
+                "definition_sentences": [
+                    EntityReference(type_="sentence", id_=id_)
+                    for id_ in definition_sentences
+                ],
+                "snippet_sentences": [
+                    EntityReference(type_="sentence", id_=id_)
+                    for id_ in snippet_sentences
+                ],
+            },
+        )
+        term_infos.append(term_info)
 
-    # Upload definitions before terms, because terms hold references to definitions that can
-    # only be resolved once the definitions have been uploaded.
-    upload_entities(
-        processing_summary.s2_id,
-        processing_summary.arxiv_id,
-        definition_infos,
-        data_version,
-    )
     upload_entities(
         processing_summary.s2_id, processing_summary.arxiv_id, term_infos, data_version,
     )

--- a/data-processing/entities/equations/__init__.py
+++ b/data-processing/entities/equations/__init__.py
@@ -1,9 +1,7 @@
 from typing import cast
 
-from common.colorize_tex import ColorizeOptions
-from common.commands.base import CommandList
 from common.parse_tex import EquationExtractor
-from common.types import CharacterRange, Equation, SerializableEntity
+from common.types import CharacterRange, ColorizeOptions, Equation, SerializableEntity
 from entities.common import create_entity_localization_command_sequence
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
 
@@ -23,7 +21,7 @@ def adjust_color_positions(entity: SerializableEntity) -> CharacterRange:
 commands = create_entity_localization_command_sequence(
     "equations",
     EquationExtractor,
-    Equation,
+    DetectedEntityType=Equation,
     colorize_options=ColorizeOptions(
         when=colorize_equation_when, adjust_color_positions=adjust_color_positions
     ),

--- a/data-processing/entities/equations/upload.py
+++ b/data-processing/entities/equations/upload.py
@@ -1,7 +1,6 @@
 from typing import Optional, cast
 
-from common.types import BoundingBox, EntityInformation, PaperProcessingResult
-from common.types import Equation
+from common.types import BoundingBox, EntityUploadInfo, Equation, PaperProcessingResult
 from common.upload_entities import upload_entities
 
 
@@ -10,11 +9,11 @@ def upload_equations(
 ) -> None:
 
     entity_infos = []
-    for entity_and_location in processing_summary.localized_entities:
-        equation = cast(Equation, entity_and_location.entity)
-        boxes = [cast(BoundingBox, l) for l in entity_and_location.locations]
+    for entity_summary in processing_summary.entities:
+        equation = cast(Equation, entity_summary.entity)
+        boxes = [cast(BoundingBox, l) for l in entity_summary.locations]
 
-        entity_info = EntityInformation(
+        entity_info = EntityUploadInfo(
             id_=f"{equation.tex_path}-{equation.id_}",
             type_="equation",
             bounding_boxes=boxes,

--- a/data-processing/entities/glossary_terms/__init__.py
+++ b/data-processing/entities/glossary_terms/__init__.py
@@ -1,10 +1,6 @@
-from common import directories
 from common.colorize_tex import ColorizeOptions
-from common.commands.upload_entities import UploadEntitiesCommand
-from common.types import SerializableEntity, Term
+from common.types import Term
 from entities.common import create_entity_localization_command_sequence
-from entities.sentences.commands.extract_contexts import make_extract_contexts_command
-from entities.sentences.types import TexWrapper
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
 
 from .colorize import adjust_color_positions
@@ -14,25 +10,10 @@ from .upload import upload_terms
 commands = create_entity_localization_command_sequence(
     "glossary-terms",
     GlossaryTermExtractor,
+    extract_contexts=True,
     DetectedEntityType=Term,
     colorize_options=ColorizeOptions(adjust_color_positions=adjust_color_positions),
     upload_func=upload_terms,
-)
-
-# Before uploading entities, extract contexts that each term appeared in.
-upload_command_index = len(commands)
-for i, command in enumerate(commands):
-    if command.get_name() == "upload-glossary-terms":
-        upload_command_index = i
-
-directories.register("contexts-for-glossary-terms")
-commands.insert(
-    upload_command_index,
-    make_extract_contexts_command(
-        "glossary-terms",
-        EntityType=Term,
-        tex_wrapper=TexWrapper(before="**", after="**"),
-    ),
 )
 
 terms_pipeline = EntityPipeline("glossary-terms", commands, depends_on=["sentences"])

--- a/data-processing/entities/glossary_terms/__init__.py
+++ b/data-processing/entities/glossary_terms/__init__.py
@@ -1,5 +1,4 @@
-from common.colorize_tex import ColorizeOptions
-from common.types import Term
+from common.types import ColorizeOptions, Term
 from entities.common import create_entity_localization_command_sequence
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
 

--- a/data-processing/entities/sentences/__init__.py
+++ b/data-processing/entities/sentences/__init__.py
@@ -1,6 +1,4 @@
-from common import directories
-from common.colorize_tex import ColorizeOptions
-from common.commands.base import CommandList
+from common.types import ColorizeOptions
 from entities.common import create_entity_localization_command_sequence
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
 

--- a/data-processing/entities/sentences/types.py
+++ b/data-processing/entities/sentences/types.py
@@ -42,29 +42,6 @@ class Sentence(SerializableEntity):
 
 
 @dataclass(frozen=True)
-class Context:
-    " A context that an entity appears in within a paper. "
-    tex_path: str
-    entity_id: str
-    " Together, 'tex_path' and 'entity_id' specify the entity that the context is for. "
-
-    sentence_id: str
-    " ID of the sentence that the entity appears in. "
-
-    snippet: str
-    """
-    A snippet of human-readable text optimized to show the entity in context. This may include HTML
-    or LaTeX, depending on the context the snippet is meant to appear in.
-    """
-
-    neighbor_entity_ids: List[str]
-    """
-    A list of entity IDs for entities of the same type that also appear in the same sentence. For
-    example, this could include IDs of other symbols of the same name in the same sentence.
-    """
-
-
-@dataclass(frozen=True)
 class TexWrapper:
     " Instructions for how to wrap an entity appearance in extracted TeX. "
 

--- a/data-processing/entities/sentences/upload.py
+++ b/data-processing/entities/sentences/upload.py
@@ -1,6 +1,6 @@
 from typing import Optional, cast
 
-from common.types import BoundingBox, EntityInformation, PaperProcessingResult
+from common.types import BoundingBox, EntityUploadInfo, PaperProcessingResult
 from common.upload_entities import upload_entities
 
 from .types import Sentence as SentenceEntity
@@ -11,11 +11,11 @@ def upload_sentences(
 ) -> None:
 
     entity_infos = []
-    for entity_and_location in processing_summary.localized_entities:
-        sentence = cast(SentenceEntity, entity_and_location.entity)
-        boxes = [cast(BoundingBox, l) for l in entity_and_location.locations]
+    for entity_summary in processing_summary.entities:
+        sentence = cast(SentenceEntity, entity_summary.entity)
+        boxes = [cast(BoundingBox, l) for l in entity_summary.locations]
 
-        entity_info = EntityInformation(
+        entity_info = EntityUploadInfo(
             id_=f"{sentence.tex_path}-{sentence.id_}",
             type_="sentence",
             bounding_boxes=boxes,

--- a/data-processing/entities/symbols/__init__.py
+++ b/data-processing/entities/symbols/__init__.py
@@ -99,7 +99,6 @@ commands = [
     FindSymbolMatches,
     make_extract_contexts_command(
         "symbols",
-        EntityType=SerializableSymbol,
         entity_key=entity_key_for_contexts,
         tex_wrapper=TexWrapper(
             before=r"\htmlClass{match-highlight}{", after="}", braces=True

--- a/data-processing/entities/symbols/__init__.py
+++ b/data-processing/entities/symbols/__init__.py
@@ -1,12 +1,13 @@
 from typing import Any, List, cast
 
 from common import directories
-from common.colorize_tex import ColorizeOptions, overlaps
+from common.colorize_tex import overlaps
 from common.commands.locate_entities import make_locate_entities_command
 from common.commands.upload_entities import make_upload_entities_command
 from common.make_digest import make_default_paper_digest
 from common.types import (
     ArxivId,
+    ColorizeOptions,
     EntityProcessingDigest,
     SerializableEntity,
     SerializableSymbol,
@@ -99,6 +100,7 @@ commands = [
     FindSymbolMatches,
     make_extract_contexts_command(
         "symbols",
+        EntityType=SerializableSymbol,
         entity_key=entity_key_for_contexts,
         tex_wrapper=TexWrapper(
             before=r"\htmlClass{match-highlight}{", after="}", braces=True

--- a/data-processing/entities/symbols/types.py
+++ b/data-processing/entities/symbols/types.py
@@ -1,8 +1,15 @@
 from dataclasses import dataclass
 from typing import Dict, List, Set
 
-from common.types import ArxivId, BoundingBox, Matches, S2Id, SymbolId, SymbolWithId
-from entities.sentences.types import Context
+from common.types import (
+    ArxivId,
+    BoundingBox,
+    Context,
+    Matches,
+    S2Id,
+    SymbolId,
+    SymbolWithId,
+)
 
 
 @dataclass(frozen=True)

--- a/data-processing/entities/symbols/upload.py
+++ b/data-processing/entities/symbols/upload.py
@@ -1,7 +1,7 @@
 import logging
 import os.path
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, cast
+from typing import Dict, List, Optional, Set, Union, cast
 
 from common import directories, file_utils
 from common.colorize_tex import wrap_span
@@ -17,6 +17,7 @@ from common.types import (
     PaperProcessingResult,
     SerializableChild,
     SerializableSymbol,
+    Symbol,
 )
 from common.upload_entities import upload_entities
 from entities.symbols.types import DefiningFormula
@@ -24,7 +25,7 @@ from entities.symbols.types import DefiningFormula
 SymbolId = str
 
 
-def sid(symbol: SerializableSymbol) -> SymbolId:
+def sid(symbol: Union[SerializableSymbol, Symbol]) -> SymbolId:
     return f"{symbol.tex_path}-{symbol.equation_index}-{symbol.symbol_index}"
 
 

--- a/data-processing/entities/symbols/upload.py
+++ b/data-processing/entities/symbols/upload.py
@@ -7,10 +7,11 @@ from common import directories, file_utils
 from common.colorize_tex import wrap_span
 from common.types import (
     BoundingBox,
+    Context,
     EntityData,
-    EntityInformation,
     EntityReference,
     EntityRelationships,
+    EntityUploadInfo,
     Match,
     Matches,
     PaperProcessingResult,
@@ -18,7 +19,6 @@ from common.types import (
     SerializableSymbol,
 )
 from common.upload_entities import upload_entities
-from entities.sentences.types import Context
 from entities.symbols.types import DefiningFormula
 
 SymbolId = str
@@ -33,11 +33,11 @@ def upload_symbols(
 ) -> None:
 
     arxiv_id = processing_summary.arxiv_id
-    entities = [el.entity for el in processing_summary.localized_entities]
+    entities = [es.entity for es in processing_summary.entities]
     symbols = cast(List[SerializableSymbol], entities)
     symbols_by_id = {sid(s): s for s in symbols}
 
-    entity_infos: List[EntityInformation] = []
+    entity_infos: List[EntityUploadInfo] = []
 
     # Load MathML matches for partially matching of symbols.
     matches: Matches = {}
@@ -123,7 +123,7 @@ def upload_symbols(
             mathml_formulas[symbol.mathml].add(formula)
 
     entity_infos = []
-    for localized_entity in processing_summary.localized_entities:
+    for localized_entity in processing_summary.entities:
 
         symbol = cast(SerializableSymbol, localized_entity.entity)
         boxes = [
@@ -196,7 +196,7 @@ def upload_symbols(
         }
 
         # Save all data for this symbol
-        entity_information = EntityInformation(
+        entity_information = EntityUploadInfo(
             id_=sid(symbol),
             type_="symbol",
             bounding_boxes=boxes,

--- a/data-processing/tests/test_colorize_tex.py
+++ b/data-processing/tests/test_colorize_tex.py
@@ -5,11 +5,10 @@ from common.colorize_tex import (
     COLOR_MACROS_BASE_MACROS,
     COLOR_MACROS_LATEX_IMPORTS,
     COLOR_MACROS_TEX_IMPORTS,
-    ColorizeOptions,
     add_color_macros,
     colorize_entities,
 )
-from common.types import SerializableEntity, SerializableToken
+from common.types import ColorizeOptions, SerializableEntity, SerializableToken
 from entities.citations.colorize import colorize_citations
 from entities.citations.types import Bibitem
 from entities.symbols.colorize import (

--- a/data-processing/tests/test_compile.py
+++ b/data-processing/tests/test_compile.py
@@ -11,17 +11,19 @@ from common.types import CompiledTexFile
 
 def test_get_compiled_tex_files():
     stdout = bytearray(
-        "[verbose]:  ~~~~~~~~~~~ Processing file 'emnlp2020.tex'\n"
+        "[verbose]:  ~~~~~~~~~~~ Processing file 'main.tex'\n" + "...\n"
+        # DVI files that are successfully processed should not be considered TeX files.
+        + "[verbose]:  ~~~~~~~~~~~ Processing file 'main.dvi'\n"
         + "...\n"
-        + "[verbose]:  ~~~~~~~~~~~ Processing file 'annoation-cost.tex'\n"
+        + "[verbose]:  ~~~~~~~~~~~ Processing file 'other.tex'\n"
         + "..."
-        + "<annoation-cost.tex> appears to be tex-type, but was neither included nor processable:"
+        + "<other.tex> appears to be tex-type, but was neither included nor processable:"
         + "...",
         "utf-8",
     )
     compiled_tex_files = get_compiled_tex_files_from_autotex_output(stdout)
     assert len(compiled_tex_files) == 1
-    assert CompiledTexFile("emnlp2020.tex") in compiled_tex_files
+    assert CompiledTexFile("main.tex") in compiled_tex_files
 
 
 def test_is_not_missing_driver():

--- a/data-processing/tests/test_locate_symbols.py
+++ b/data-processing/tests/test_locate_symbols.py
@@ -8,6 +8,9 @@ def token_id(start: int, end: int) -> TokenId:
 
 def symbol(tokens, start=-1, end=-1):
     return Symbol(
+        tex_path="main.tex",
+        equation_index=0,
+        symbol_index=0,
         tex="<symbol-tex>",
         tokens=tokens,
         mathml="<mathml>",


### PR DESCRIPTION
Recently, Dongyeop and Vivek updated the definition extractor to have higher recall and precision. Since then, the data format expected by the UI got out-of-step with the data uploaded from the definition extractor.

This PR includes changes that upload definitions extracted for both tems and symbols to the database in a format that the ScholarPhi UI expects. As a result, you can see that for papers like `1601.00978`, symbol nicknames like `x` are clickable, their definitions show up, and declutter is supported for terms detected by the definition detector.

![image](https://user-images.githubusercontent.com/2358524/102287089-889c1100-3eee-11eb-849b-9f8127f8d2a8.png)

@rreas and @dykang I would appreciate if you two take a look! I realize the code is tangled, though it's probably a good thing to have others on the team familiar with this code as we approach alpha. Of particular note is the file `entities/definitions/upload.py`, where the biggest logical changes were made.

Smaller changes include:

* renaming `acronym*` variables to `abbreviation*` in definition detector
* moving the 'Context' type into the `common.types` instead of `entities.sentences.types`