### PR TITLE
Query S2's API using an API key if we have one + some other cleanup.

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,9 @@
 # Scholar Reader API
 
-The API server for the Scholar Reader application. For a 
-given paper, the application needs to know about the 
-citations, symbols, and other entities in that paper and 
-where they are located. This server provides that data upon 
+The API server for the Scholar Reader application. For a
+given paper, the application needs to know about the
+citations, symbols, and other entities in that paper and
+where they are located. This server provides that data upon
 request.
 
 To run the server, first install the dependencies:
@@ -26,36 +26,38 @@ curl 0.0.0.0:3000/api/health
 
 And you should see a response of 👍.
 
-Examples of valid API calls can be found by looking at the 
-routes in the `api.ts` script, or at the API calls made from 
+Examples of valid API calls can be found by looking at the
+routes in the `api.ts` script, or at the API calls made from
 the `ui` code in the `ScholarReader.tsx` file.
 
-## Configuring the server to access the database
+## One Time Setup
 
-Several of the API endpoints assume the server has access to 
-a private database. The server code already includes _some_ 
-login information. However, you must get the password from 
-one of the database administrators (at the time of writing 
-this, andrewhead@berkeley.edu). Once you have this password, 
-create a file named `config/secret.json` with these 
-contents:
+The API uses several secrets at runtime to:
 
-```json
-{
-  "database": {
-    "password": "<password>"
-  }
-}
-```
+- Access a database, where information about the papers and
+  the entities we extract from them is stored.
+- Query [Semantic Scholar's Public API](https://api.semanticscholar.org/).
 
-Once you have, you can relaunch the server, and it should be 
-capable of querying for data from the database.
+The API queries work without an API key, but will get rate
+limited if you make more than 100 queries in 5 minutes.
+This can happen relatively quickly during normal use of the
+application.
+
+The database won't workout without the appropriate
+configuration.
+
+You can get these values by getting in touch with an administrator.
+At the time of writing this, [andrewhead@berkeley.edu](mailto:andrewhead@berkeley.edu)
+is one. Once you have the values, put them in a file called
+`config/secret.json`, after which your application should
+be able to to query the database and Semantic Scholar's public
+API.
 
 ## Running the Tests
 
-The tests use a local database that's ran in in [docker](https://www.docker.com/).
-If you don't have `docker` installed, you'll need to install it to
-run the tests.
+The tests use a local database that's run in [docker](https://www.docker.com/).
+If you don't have `docker` installed, you'll need to install
+it first.
 
 First, start the local database:
 

--- a/api/README.md
+++ b/api/README.md
@@ -49,8 +49,24 @@ configuration.
 You can get these values by getting in touch with an administrator.
 At the time of writing this, [andrewhead@berkeley.edu](mailto:andrewhead@berkeley.edu)
 is one. Once you have the values, put them in a file called
-`config/secret.json`, after which your application should
-be able to to query the database and Semantic Scholar's public
+`config/secret.json`. The result will look something like this:
+
+```json
+{
+  "database": {
+    "password": "<password>"
+    "host": "<hostname>",
+    "database": "<dbname>",
+    "user": "<user>"
+  },
+  "s2": {
+    "apiKey": "<key>"
+  }
+}
+```
+
+After doing this you can start your API server, which should now
+have the ability to freely query the database or S2's Public
 API.
 
 ## Running the Tests

--- a/api/README.md
+++ b/api/README.md
@@ -54,7 +54,7 @@ is one. Once you have the values, put them in a file called
 ```json
 {
   "database": {
-    "password": "<password>"
+    "password": "<password>",
     "host": "<hostname>",
     "database": "<dbname>",
     "user": "<user>"

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1704,6 +1704,11 @@
         }
       }
     },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
+    },
     "@types/mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
@@ -5681,6 +5686,14 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7841,6 +7854,11 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
       "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -32,8 +32,10 @@
   "dependencies": {
     "@hapi/hapi": "^18.4.1",
     "@hapi/joi": "^16.1.7",
+    "@types/lru-cache": "^5.1.0",
     "axios": "^0.21.0",
     "knex": "^0.21.13",
+    "lru-cache": "^6.0.0",
     "nconf": "^0.11.0",
     "pg": "^8.5.1"
   }

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -52,7 +52,7 @@ export const plugin = {
         // We fetch metadata about each paper (it's title, author names, etc) from S2's public
         // API and merged them into the result set.
         const s2PaperInfoByPaperId: { [pid: string]: Paper } = {};
-        for (const s2Paper of await s2Api.getPapers(paperIds, config.s2.apiKey, true)) {
+        for (const s2Paper of await s2Api.getPapers(paperIds, config.s2.apiKey, false)) {
           if (!s2Paper) {
             continue;
           }

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -2,11 +2,32 @@ import * as Hapi from "@hapi/hapi";
 import * as Joi from "@hapi/joi";
 import { Connection } from "./db-connection";
 import * as s2Api from "./s2-api";
-import { EntityCreatePayload, EntityUpdatePayload, Paper } from "./types/api";
+import {
+  EntityCreatePayload,
+  EntityUpdatePayload,
+  Paper,
+  PaperWithEntityCounts,
+  Paginated
+} from "./types/api";
 import * as validation from "./types/validation";
+import * as conf from "./conf";
 
 interface ApiOptions {
   connection: Connection;
+  config: conf.Config;
+}
+
+function firstQueryStringValue(request: Hapi.Request, name: string): string | undefined {
+  const v = request.query[name];
+  return Array.isArray(v) ? v.shift() : v;
+}
+
+function firstIntOrDefault(request: Hapi.Request, name: string, defaultValue: number): number {
+  const v = parseInt(firstQueryStringValue(request, name) || "");
+  if (isNaN(v)) {
+    return defaultValue;
+  }
+  return v;
 }
 
 /**
@@ -16,36 +37,48 @@ export const plugin = {
   name: "API",
   version: "0.0.2",
   register: async function (server: Hapi.Server, options: ApiOptions) {
-    const { connection: dbConnection } = options;
+    const { connection: dbConnection, config } = options;
 
     server.route({
       method: "GET",
       path: "papers/list",
       handler: async (request) => {
-        let offset;
-        if ('offset' in request.query) {
-          const o = parseInt(
-            Array.isArray(request.query.offset)
-              ? request.query.offset[0]
-              : request.query.offset
-          );
-          if (!isNaN(o)) {
-            offset = o;
-          }
-        }
-        let size;
-        if ('size' in request.query) {
-          const s = parseInt(
-            Array.isArray(request.query.size)
-              ? request.query.size[0]
-              : request.query.size
-          );
-          if (!isNaN(s)) {
-            size = Math.min(s, 100);
-          }
-        }
+        const offset = firstIntOrDefault(request, "offset", 0);
+        const size = firstIntOrDefault(request, "size", 25);
+
         const papers = await dbConnection.getAllPapers(offset, size);
-        return papers;
+        const paperIds = papers.rows.map(p => p.s2_id);
+
+        // We fetch metadata about each paper (it's title, author names, etc) from S2's public
+        // API and merged them into the result set.
+        const s2PaperInfoByPaperId: { [pid: string]: Paper } = {};
+        for (const s2Paper of await s2Api.getPapers(paperIds, config.s2.apiKey, true)) {
+          if (!s2Paper) {
+            continue;
+          }
+          if (s2Paper.s2Id in s2PaperInfoByPaperId) {
+            console.warn(`Duplicate paper id: ${s2Paper.s2Id}`);
+            continue;
+          }
+          s2PaperInfoByPaperId[s2Paper.s2Id] = s2Paper;
+        }
+        const mergedPapers: PaperWithEntityCounts[] = [];
+        for (const paper of papers.rows) {
+          const maybeS2Paper = s2PaperInfoByPaperId[paper.s2_id];
+          mergedPapers.push({
+            ...paper,
+            abstract: maybeS2Paper?.abstract,
+            authors: maybeS2Paper?.authors,
+            title: maybeS2Paper?.title,
+            url: maybeS2Paper?.url,
+            venue: maybeS2Paper?.venue,
+            year: maybeS2Paper?.year,
+            influentialCitationCount: maybeS2Paper?.influentialCitationCount,
+            citationVelocity: maybeS2Paper?.citationVelocity
+          });
+        }
+        const response: Paginated<PaperWithEntityCounts> = { ...papers, ...{ rows: mergedPapers } };
+        return response;
       },
     });
 
@@ -63,7 +96,7 @@ export const plugin = {
         const uniqueIds = ids.filter((id, index) => {
           return ids.indexOf(id) === index;
         });
-        const data = (await s2Api.getPapers(uniqueIds))
+        const data = (await s2Api.getPapers(uniqueIds, config.s2.apiKey))
           .filter((paper) => paper !== undefined)
           .map((paper) => paper as Paper)
           .map((paper) => ({

--- a/api/src/conf.ts
+++ b/api/src/conf.ts
@@ -1,0 +1,47 @@
+/**
+ * This module provides type information for the bits of configuration the API needs.
+ * We use classes instead of interfaces to enforce the immutability of the values.
+ */
+import * as nconf from 'nconf';
+
+export class DBConfig {
+    public constructor(
+        readonly host: string,
+        readonly database: string,
+        readonly user: string,
+        readonly password: string,
+        readonly port?: number,
+        readonly schema?: string
+    ) {}
+
+    public withoutSchema(): DBConfig {
+        return new DBConfig(
+            this.host,
+            this.database,
+            this.user,
+            this.password,
+            this.port
+        );
+    }
+}
+
+export class S2APIConfig {
+    public constructor(readonly apiKey?: string) {}
+}
+
+export class Config {
+    constructor(
+        readonly db: DBConfig,
+        readonly s2: S2APIConfig
+    ) {}
+
+    static fromConfig(conf: nconf.Provider) {
+        const db = conf.get("database");
+        const s2 = conf.get("s2"); 
+        const algolia = conf.get("algolia");
+        return new Config(
+            new DBConfig(db.host, db.database, db.user, db.password, db.port, db.schema),
+            new S2APIConfig(s2 && s2.apiKey)
+        );
+    }
+}

--- a/api/src/conf.ts
+++ b/api/src/conf.ts
@@ -38,7 +38,6 @@ export class Config {
     static fromConfig(conf: nconf.Provider) {
         const db = conf.get("database");
         const s2 = conf.get("s2"); 
-        const algolia = conf.get("algolia");
         return new Config(
             new DBConfig(db.host, db.database, db.user, db.password, db.port, db.schema),
             new S2APIConfig(s2 && s2.apiKey)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,5 +1,6 @@
 import * as nconf from "nconf";
 import ApiServer from "./server";
+import { Config } from "./conf";
 
 nconf
   .argv()
@@ -17,5 +18,5 @@ process.on("unhandledRejection", (err) => {
   process.exit(1);
 });
 
-const server = new ApiServer(nconf, true);
+const server = new ApiServer(Config.fromConfig(nconf), true);
 server.init().then(() => server.start());

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -28,7 +28,6 @@ export interface PaperIdWithEntityCounts {
   sentence_count: number;
   term_count: number;
   equation_count: number;
-  definition_count: number;
   entity_count: number;
 }
 
@@ -44,6 +43,17 @@ export interface Paper {
   url: string;
   venue: string;
   year: number | null;
+  influentialCitationCount?: number;
+  citationVelocity?: number;
+}
+
+export interface PaperWithEntityCounts extends PaperIdWithEntityCounts {
+  abstract?: string;
+  authors?: Author[];
+  title?: string;
+  url?: string;
+  venue?: string;
+  year?: number | null;
   influentialCitationCount?: number;
   citationVelocity?: number;
 }

--- a/api/src/types/s2-api.ts
+++ b/api/src/types/s2-api.ts
@@ -1,17 +1,3 @@
-export type S2ApiResponse = S2ApiError | S2ApiSuccess;
-
-export function isS2ApiResponseSuccess(response: any): response is S2ApiSuccess {
-  return response.error === undefined && response.status === 200;
-}
-
-interface S2ApiError {
-  error: string;
-}
-
-interface S2ApiSuccess {
-  data: S2ApiPaper;
-  status: 200;
-}
 
 export interface S2ApiPaper {
   abstract: string;

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -13,8 +13,9 @@ import {
 } from "./types/api";
 
 export async function listPapers(offset: number = 0, size: number = 25) {
-  return await doGet<Paginated<PaperIdWithEntityCounts>>(
-      axios.get("/api/v0/papers/list", { params: { offset, size }})
+  return axios.get<Paginated<PaperIdWithEntityCounts>>(
+    "/api/v0/papers/list",
+    { params: { offset, size } }
   );
 }
 

--- a/ui/src/papers/index.tsx
+++ b/ui/src/papers/index.tsx
@@ -85,10 +85,6 @@ function getSizeFromURL(defaultSize: number): number {
   return s;
 }
 
-/**
- * SAM TO DO:
- * - Display Algolia logo on search results (or update to paid account)
- */
 const PaperList = () => {
   const [ query, setListRequest ] = useState<ListRequest>(new ListRequest(
     getOffsetFromURL(0),

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -357,8 +357,18 @@ export interface PaperIdWithEntityCounts {
   sentence_count: number;
   term_count: number;
   equation_count: number;
-  definition_count: number;
   entity_count: number;
+}
+
+export interface PaperWithEntityCounts extends PaperIdWithEntityCounts {
+  abstract?: string;
+  authors?: Author[];
+  title?: string;
+  url?: string;
+  venue?: string;
+  year?: number | null;
+  influentialCitationCount?: number;
+  citationVelocity?: number;
 }
 
 /**


### PR DESCRIPTION
This PR started as an effort to add search, but as discussed I ended
up pausing on that change in favor of eventually using S2's regular
search API. This PR instead captures changes that I made while
implementing search that seem worth preserving.

The largest functional difference is that the API now uses an API
key when querying S2's public API. This means we can safely query
for this information in the backend when preparing papers to return
for the `/papers/list` API endpoint.

To do this I did some cleanup of the way configuration parameters
are handled so that they can be accessed in a typesafe fashion.

Lastly I cleaned up the paper list UI a bit, as it was getting
a little unruly.