### PR TITLE
Add loading indicator for citation data

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -37,6 +37,7 @@ class ApiServer {
     const connectionParams = extractConnectionParams(this._config);
     const dbConnection = new Connection(connectionParams);
     this._dbConnection = dbConnection;
+    console.log(`Using database at ${connectionParams.host}`);
 
     /**
      * Register API endpoints.

--- a/ui/src/PrimerPage.tsx
+++ b/ui/src/PrimerPage.tsx
@@ -18,6 +18,7 @@ interface Props {
   annotationHintsEnabled: boolean;
   termGlossesEnabled: boolean;
   scrollToPageOnLoad?: boolean;
+  isCitationsLoading?: boolean;
   handleSetAnnotationHintsEnabled: (enabled: boolean) => void;
 }
 
@@ -67,6 +68,7 @@ class PrimerPage extends React.PureComponent<Props> {
       entities,
       showInstructions,
       termGlossesEnabled,
+      isCitationsLoading,
     } = this.props;
 
     /*
@@ -83,8 +85,9 @@ class PrimerPage extends React.PureComponent<Props> {
     }
     this._element.style.width = width;
 
-    const terms = entities !== null ? glossaryTerms(entities) : [];
-    const symbols = entities !== null ? glossarySymbols(entities) : [];
+    const isEntitiesLoaded = (entities: Entities | null): entities is Entities => ( entities !== null );
+    const terms = isEntitiesLoaded(entities) ? glossaryTerms(entities) : [];
+    const symbols = isEntitiesLoaded(entities) ? glossarySymbols(entities) : [];
 
     return ReactDOM.createPortal(
       <>
@@ -161,15 +164,32 @@ class PrimerPage extends React.PureComponent<Props> {
               </div>
             </>
           )}
-          {entities === null ? (
-            <>
-              <p className="primer-page__header">
-                Building a glossary of key terms and symbols for this paper...
-              </p>
-              <p>Please wait... Scanning paper...</p>
-              <LinearProgress />
-            </>
-          ) : (
+          {
+            (isCitationsLoading || !isEntitiesLoaded(entities)) && (
+              <>
+                <p className="primer-page__header">
+                  Preparing paper for interactive viewing...
+                </p>
+                {
+                  isCitationsLoading && (
+                    <>
+                      <p>Loading citation data...</p>
+                      <LinearProgress />
+                    </>
+                  )
+                }
+                {
+                  !isEntitiesLoaded(entities) && (
+                    <>
+                      <p>Building a glossary of key terms and symbols..</p>
+                      <LinearProgress />
+                    </>
+                  )
+                }
+              </>
+            )
+          }
+          {isEntitiesLoaded(entities) && (
             <>
               {termGlossesEnabled && terms.length > 0 ? (
                 <>

--- a/ui/src/PrimerPage.tsx
+++ b/ui/src/PrimerPage.tsx
@@ -18,7 +18,7 @@ interface Props {
   annotationHintsEnabled: boolean;
   termGlossesEnabled: boolean;
   scrollToPageOnLoad?: boolean;
-  isCitationsLoading?: boolean;
+  areCitationsLoading?: boolean;
   handleSetAnnotationHintsEnabled: (enabled: boolean) => void;
 }
 
@@ -68,7 +68,7 @@ class PrimerPage extends React.PureComponent<Props> {
       entities,
       showInstructions,
       termGlossesEnabled,
-      isCitationsLoading,
+      areCitationsLoading,
     } = this.props;
 
     /*
@@ -165,13 +165,13 @@ class PrimerPage extends React.PureComponent<Props> {
             </>
           )}
           {
-            (isCitationsLoading || !isEntitiesLoaded(entities)) && (
+            (areCitationsLoading || !isEntitiesLoaded(entities)) && (
               <>
                 <p className="primer-page__header">
                   Preparing paper for interactive viewing...
                 </p>
                 {
-                  isCitationsLoading && (
+                  areCitationsLoading && (
                     <>
                       <p>Loading citation data...</p>
                       <LinearProgress />

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -91,7 +91,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
 
       controlPanelShowing: false,
 
-      isCitationsLoading: false,
+      areCitationsLoading: false,
 
       selectedAnnotationIds: [],
       selectedAnnotationSpanIds: [],
@@ -729,7 +729,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
     if (this.props.paperId !== undefined) {
       if (this.props.paperId.type === "arxiv") {
         this.setState({
-          isCitationsLoading: true
+          areCitationsLoading: true
         });
         const entities = await api.getEntities(this.props.paperId.id);
         this.setState({
@@ -749,7 +749,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             },
             {} as { [s2Id: string]: Paper }
           );
-          this.setState({ papers, isCitationsLoading: false });
+          this.setState({ papers, areCitationsLoading: false });
         }
 
         const userData = await api.getUserLibraryInfo();
@@ -1015,7 +1015,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             showInstructions={this.state.primerInstructionsEnabled}
             scrollToPageOnLoad={this.state.initialFocus === null}
             handleSetAnnotationHintsEnabled={this.setAnnotationHintsEnabled}
-            isCitationsLoading={this.state.isCitationsLoading}
+            areCitationsLoading={this.state.areCitationsLoading}
           />
         ) : null}
         {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -91,6 +91,8 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
 
       controlPanelShowing: false,
 
+      isCitationsLoading: false,
+
       selectedAnnotationIds: [],
       selectedAnnotationSpanIds: [],
       selectedEntityIds: [],
@@ -726,6 +728,9 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
   loadDataFromApi = async (): Promise<void> => {
     if (this.props.paperId !== undefined) {
       if (this.props.paperId.type === "arxiv") {
+        this.setState({
+          isCitationsLoading: true
+        });
         const entities = await api.getEntities(this.props.paperId.id);
         this.setState({
           entities: stateUtils.createRelationalStoreFromArray(entities, "id"),
@@ -744,7 +749,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             },
             {} as { [s2Id: string]: Paper }
           );
-          this.setState({ papers });
+          this.setState({ papers, isCitationsLoading: false });
         }
 
         const userData = await api.getUserLibraryInfo();
@@ -1010,6 +1015,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             showInstructions={this.state.primerInstructionsEnabled}
             scrollToPageOnLoad={this.state.initialFocus === null}
             handleSetAnnotationHintsEnabled={this.setAnnotationHintsEnabled}
+            isCitationsLoading={this.state.isCitationsLoading}
           />
         ) : null}
         {

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -67,7 +67,7 @@ export interface State extends Settings {
    * ~ Loading states ~
    */
 
-  isCitationsLoading: boolean;
+  areCitationsLoading: boolean;
   /*
    * ~ App control panel ~
    */

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -62,6 +62,12 @@ export interface State extends Settings {
   /*
    * *** USER INTERFACE STATE ***
    */
+
+  /*
+   * ~ Loading states ~
+   */
+
+  isCitationsLoading: boolean;
   /*
    * ~ App control panel ~
    */
@@ -106,7 +112,7 @@ export interface State extends Settings {
   snackbarActivationTimeMs: number | null;
   snackbarMessage: string | null;
 
-  /* 
+  /*
    * ~ Find bar state ~
   /**
    * When 'isFindActive' is false, the rest of the properties for finding should be set to null.


### PR DESCRIPTION
Ref https://github.com/allenai/scholar/issues/25245

I reworked the part of the PrimerPage that displayed the loading indicator for entity/definition data to also indicate whether or not we've loaded citation data.

Preview:
![](http://g.recordit.co/Q36pvNM8fm.gif)