### PR TITLE
Pipeline: Fix up command filters; disable glossary terms by default

### DIFF
--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -383,9 +383,9 @@ if __name__ == "__main__":
     # Determine the entities that will be processed. If no entities were specified,
     # then set the entities to the default (or empty if a list of commands was provided).
     entities: List[str] = []
-    if args.entities is not None:
+    if args.entities:
         entities = args.entities
-    elif args.commands is None or (args.start or args.end):
+    elif not args.commands or args.start or args.end:
         entities = DEFAULT_ENTITIES
 
     start_reached = True if args.start is None else False
@@ -399,7 +399,7 @@ if __name__ == "__main__":
                 continue
             # If no other command filters have been specified and the user didn't
             # request this command, skip it.
-            if args.start is None and args.end is None and entities == []:
+            if not args.start and not args.end and not entities:
                 continue
         if end_reached:
             continue


### PR DESCRIPTION
This PR serves two purposes.

First, it disables the detection of glossary terms by the pipeline by default. This is because the glossary terms appear so often in papers, and provide such generic definitions, that I believe it will be better to disable them in our first alpha tests. Paper-specific terms and definitions (i.e., that appear within a paper, rather than in an external glossary like the Google Machine Learning Glossary) will still be extracted by default via the `definitions` entity type.

Second, it fixes buggy behavior in the pipeline arguments that filter which stages of the pipeline are run (e.g., `--entities`, `--commands`, `--start`, and `--end`. Namely, it supports:

* Default lists of entities to process that is not all entities but rather a subset (i.e., citations, symbols, and definitions)
* It allows specified in `--commands` to be run even after they appear after the `--end` filter

The following tests demonstrate that the filter arguments now achieving the desired behavior.

### Test 1: default behavior omits processing glossary terms:

```
bash
python scripts/run_pipeline.py -v 2>&1 | head -4`
```

Output:

```
...The following commands will be run, in this order: ['fetch-arxiv-sources', 'fetch-s2-metadata', 'unpack-sources', 'compile-tex', 'normalize-tex', 'compile-normalized-tex', 'raster-pages', 'extract-bibitems', 'resolve-bibitems', 'locate-bounding-boxes-for-citations', 'locate-citations', 'upload-citations', 'detect-sentences', 'locate-bounding-boxes-for-sentences', 'upload-sentences', 'detect-equations', 'locate-bounding-boxes-for-equations', 'upload-equations', 'extract-symbols', 'find-symbol-matches', 'extract-contexts-for-symbols', 'locate-bounding-boxes-for-equation-tokens', 'locate-bounding-boxes-for-symbols-with-affixes', 'locate-composite-symbols', 'collect-symbol-locations', 'upload-symbols', 'tokenize-sentences', 'create-annotation-files', 'detect-definitions', 'locate-bounding-boxes-for-definitions', 'upload-definitions']
```

### Test 2: Specifying commands without any other filters results in running just those commands

```bash
python scripts/run_pipeline.py -v --commands upload-citations 2>&1 | head -4
```

Output:
```
...The following commands will be run, in this order: ['upload-citations']
```

### Test 3: Specifying both `--entities` and `--commands` adds the command from 'commands' to the list of commands for the specified entity.

```bash
python scripts/run_pipeline.py -v --entities glossary-terms --commands upload-citations 2>&1 | head -4
```

Output (see 'upload-citations' about halfway through the list):

```
...The following commands will be run, in this order: ['fetch-arxiv-sources', 'fetch-s2-metadata', 'unpack-sources', 'compile-tex', 'normalize-tex', 'compile-normalized-tex', 'raster-pages', 'upload-citations', 'detect-sentences', 'locate-bounding-boxes-for-sentences', 'upload-sentences', 'detect-glossary-terms', 'locate-bounding-boxes-for-glossary-terms', 'extract-contexts-for-glossary-terms', 'upload-glossary-terms']
```

### Test 4: `--start` and `--end` filters apply to the list of commands for entities, but don't filter out the commands from `--commands`

```bash
python scripts/run_pipeline.py -v --entities glossary-terms --commands upload-citations --start detect-sentences --end upload-sentences  2>&1 | head -4
```

Output:

```
The following commands will be run, in this order: ['upload-citations', 'detect-sentences', 'locate-bounding-boxes-for-sentences', 'upload-sentences']
```