### PR TITLE
[WIP] Improve quality of definitions extracted by rule-based nickname detector

### DIFF
--- a/data-processing/entities/definitions/commands/detect_definitions.py
+++ b/data-processing/entities/definitions/commands/detect_definitions.py
@@ -440,25 +440,6 @@ def get_symbol_nickname_pairs(
                         token_index, pos, ranges, direction
                     )
                     if nickname is not None and range_.start in symbol_texs:
-                        nickname_start = min(
-                            [
-                                nickname_range.start
-                                for nickname_range in nickname.token_ranges
-                            ]
-                        )
-                        nickname_end = (
-                            max(
-                                [
-                                    nickname_range.end
-                                    for nickname_range in nickname.token_ranges
-                                ]
-                            )
-                            + 1
-                        )
-                        nickname_text = text[nickname_start:nickname_end]
-                        # Reject a nickname if the nickname text is "SYMBOL".
-                        if nickname_text == "SYMBOL":
-                            continue
                         symbol_nickname_pairs.append(
                             SymbolNickname(
                                 symbol_texs[range_.start],
@@ -482,7 +463,11 @@ def get_symbol_nickname_pairs(
             nickname_end = (
                 max([nickname_range.end for nickname_range in sn.nickname_ranges]) + 1
             )
-
+            nickname_text = text[nickname_start:nickname_end]
+            # Reject a nickname if the nickname text is "SYMBOL".
+            if nickname_text == "SYMBOL":
+                continue
+            
             pair = TermDefinitionPair(
                 term_start=symbol_start,
                 term_end=symbol_end,
@@ -491,7 +476,7 @@ def get_symbol_nickname_pairs(
                 term_confidence=None,
                 definition_start=nickname_start,
                 definition_end=nickname_end,
-                definition_text=text[nickname_start:nickname_end],
+                definition_text=nickname_text,
                 definition_type="nickname",
                 definition_confidence=None,
             )

--- a/data-processing/tests/test_extract_definitions.py
+++ b/data-processing/tests/test_extract_definitions.py
@@ -85,6 +85,70 @@ def test_extract_nicknames_from_before_symbols():
     assert nickname1.definition_text == "timestep"
 
 
+def test_extract_nicknames_symbols_separated_by_colon():
+    text = "The agent acts with SYMBOL in each timestep SYMBOL, where SYMBOL : policy."
+    symbol_texs = {20: r"\pi", 44: "t", 58: r"\pi"}
+    tokens, pos = list(
+        zip(
+            *[
+                ("The", "DT"),
+                ("agent", "NN"),
+                ("acts", "VBZ"),
+                ("with", "IN"),
+                ("SYMBOL", "NN"),
+                ("in", "IN"),
+                ("each", "DT"),
+                ("timestep", "NN"),
+                ("SYMBOL", "NN"),
+                (",", ","),
+                ("where", ""),
+                ("SYMBOL", "NN"),
+                (":", ":"),
+                ("policy", "NN"),
+                (".", "."),
+            ]
+        )
+    )
+
+    symbol_nickname_pairs = get_symbol_nickname_pairs(text, tokens, pos, symbol_texs)
+    assert len(symbol_nickname_pairs) == 2
+
+    nickname0 = symbol_nickname_pairs[0]
+    assert nickname0.term_text == "t"
+    assert nickname0.definition_text == "timestep"
+
+    nickname1 = symbol_nickname_pairs[1]
+    assert nickname1.term_text == r"\pi"
+    assert nickname1.definition_text == "policy"
+
+def test_extract_nicknames_symbols_filter():
+    text = "The agent acts with SYMBOL SYMBOL in each timestep SYMBOL."
+    symbol_texs = {20: r"\pi", 27: "p", 51: "t"}
+    tokens, pos = list(
+        zip(
+            *[
+                ("The", "DT"),
+                ("agent", "NN"),
+                ("acts", "VBZ"),
+                ("with", "IN"),
+                ("SYMBOL", "NN"),
+                ("SYMBOL", "NN"),
+                ("in", "IN"),
+                ("each", "DT"),
+                ("timestep", "NN"),
+                ("SYMBOL", "NN"),
+                (".", "."),
+            ]
+        )
+    )
+
+    symbol_nickname_pairs = get_symbol_nickname_pairs(text, tokens, pos, symbol_texs)
+    assert len(symbol_nickname_pairs) == 1
+
+    nickname0 = symbol_nickname_pairs[0]
+    assert nickname0.term_text == "t"
+    assert nickname0.definition_text == "timestep"
+
 def test_extract_nicknames_from_after_symbols():
     text = "The architecture consists of SYMBOL dense layers trained with SYMBOL learning rate."
     symbol_texs = {29: "L_d", 62: r"\alpha"}

--- a/data-processing/tests/test_extract_definitions.py
+++ b/data-processing/tests/test_extract_definitions.py
@@ -86,8 +86,8 @@ def test_extract_nicknames_from_before_symbols():
 
 
 def test_extract_nicknames_symbols_separated_by_colon():
-    text = "The agent acts with SYMBOL in each timestep SYMBOL, where SYMBOL : policy."
-    symbol_texs = {20: r"\pi", 44: "t", 58: r"\pi"}
+    text = "The agent acts with SYMBOL : policy."
+    symbol_texs = {20: r"\pi"}
     tokens, pos = list(
         zip(
             *[
@@ -95,13 +95,6 @@ def test_extract_nicknames_symbols_separated_by_colon():
                 ("agent", "NN"),
                 ("acts", "VBZ"),
                 ("with", "IN"),
-                ("SYMBOL", "NN"),
-                ("in", "IN"),
-                ("each", "DT"),
-                ("timestep", "NN"),
-                ("SYMBOL", "NN"),
-                (",", ","),
-                ("where", ""),
                 ("SYMBOL", "NN"),
                 (":", ":"),
                 ("policy", "NN"),
@@ -111,19 +104,16 @@ def test_extract_nicknames_symbols_separated_by_colon():
     )
 
     symbol_nickname_pairs = get_symbol_nickname_pairs(text, tokens, pos, symbol_texs)
-    assert len(symbol_nickname_pairs) == 2
+    assert len(symbol_nickname_pairs) == 1
 
     nickname0 = symbol_nickname_pairs[0]
-    assert nickname0.term_text == "t"
-    assert nickname0.definition_text == "timestep"
+    assert nickname0.term_text == r"\pi"
+    assert nickname0.definition_text == "policy"
 
-    nickname1 = symbol_nickname_pairs[1]
-    assert nickname1.term_text == r"\pi"
-    assert nickname1.definition_text == "policy"
 
-def test_extract_nicknames_symbols_filter():
-    text = "The agent acts with SYMBOL SYMBOL in each timestep SYMBOL."
-    symbol_texs = {20: r"\pi", 27: "p", 51: "t"}
+def test_extract_nicknames_symbols_parentheses():
+    text = "The agent acts with policy (SYMBOL)."
+    symbol_texs = {28: r"\pi"}
     tokens, pos = list(
         zip(
             *[
@@ -131,12 +121,10 @@ def test_extract_nicknames_symbols_filter():
                 ("agent", "NN"),
                 ("acts", "VBZ"),
                 ("with", "IN"),
+                ("policy", "NN"),
+                ("(", "-LRB-"),
                 ("SYMBOL", "NN"),
-                ("SYMBOL", "NN"),
-                ("in", "IN"),
-                ("each", "DT"),
-                ("timestep", "NN"),
-                ("SYMBOL", "NN"),
+                (")", "-RRB-"),
                 (".", "."),
             ]
         )
@@ -146,8 +134,30 @@ def test_extract_nicknames_symbols_filter():
     assert len(symbol_nickname_pairs) == 1
 
     nickname0 = symbol_nickname_pairs[0]
-    assert nickname0.term_text == "t"
-    assert nickname0.definition_text == "timestep"
+    assert nickname0.term_text == r"\pi"
+    assert nickname0.definition_text == "policy"
+
+
+def test_extract_nicknames_symbols_filter():
+    text = "The agent acts with SYMBOL SYMBOL."
+    symbol_texs = {20: r"\pi", 27: "p"}
+    tokens, pos = list(
+        zip(
+            *[
+                ("The", "DT"),
+                ("agent", "NN"),
+                ("acts", "VBZ"),
+                ("with", "IN"),
+                ("SYMBOL", "NN"),
+                ("SYMBOL", "NN"),
+                (".", "."),
+            ]
+        )
+    )
+
+    symbol_nickname_pairs = get_symbol_nickname_pairs(text, tokens, pos, symbol_texs)
+    assert len(symbol_nickname_pairs) == 0
+
 
 def test_extract_nicknames_from_after_symbols():
     text = "The architecture consists of SYMBOL dense layers trained with SYMBOL learning rate."


### PR DESCRIPTION
@nuwandavek is leading the creation of this PR to:

1. Filter out low-quality nicknames consisting mostly of other symbols
2. Detecting other types of nickanmes (e.g., ones of the form "<symbol>: <nickname>"

I will let @nuwandavek add additional clarifications here.