### PR TITLE
When processing references, extract text from hyperlinks

### DIFF
--- a/data-processing/entities/citations/extractor.py
+++ b/data-processing/entities/citations/extractor.py
@@ -52,6 +52,13 @@ class BibitemExtractor:
         for content in list(bibitem.contents)[1:]:
             if isinstance(content, TexNode) and content.string is not None:
                 text += content.string
+            elif (
+                isinstance(content, TexNode)
+                and content.name == "hyperref"
+                and len(content.args) >= 2
+                and isinstance(content.args[1], RArg)
+            ):
+                text += content.args[1].value
             # One common pattern in TeX is to force capitalization for a bibliography entry by
             # surrounding tokens with curly braces. This gets interpreted (incorrectly)
             # by TeXSoup as an RArg. Here, the contents of an RArg are extracted as literal

--- a/data-processing/tests/test_parse_tex.py
+++ b/data-processing/tests/test_parse_tex.py
@@ -447,6 +447,16 @@ def test_extract_bibitem_stop_at_newline():
     assert bibitems[0].text == "token1"
 
 
+def test_extract_bibitem_include_hyperref_contents():
+    tex = "\n".join(
+        ["\\bibitem[label]{key1}", r"token1 \hyperref{https://url.com}{token2}"]
+    )
+    extractor = BibitemExtractor()
+    bibitems = list(extractor.parse(tex))
+    assert len(bibitems) == 1
+    assert bibitems[0].text == "token1 token2"
+
+
 def test_extract_macro():
     tex = "\\macro"
     extractor = MacroExtractor()


### PR DESCRIPTION
This PR fixes an error that caused two problems with citations:

* Some citations were resolving to the wrong paper
* Some citations were not getting detected

It turned out that the issue was with hyperlinks that appear in the references section of a paper. The pipeline maps from citations to papers in a three-step process:

1. Process the references: for each reference in a `.bbl` file, extract the LaTeX citation key, and the text for the reference, including title, authors, and venue, if they're present.
2. Fetch details for references---including titles and S2 IDs---for the paper using the Semantic Scholar API
3. Map each reference from the `.bbl` file to an S2 ID by looking for a partial match between the reference title and authors and the text extracted from the bbl file.

The problem was that our utility for extracting the reference text from bbl files left out reference text that was a hyperlink. For some well-known AI conferences, titles are often hyperlinked by default, meaning that the title information for many citations was not present when matching citations to data from the S2 API. This meant that many citations were getting matched to the wrong paper, and some citations were not matched to any paper, because there was insufficient overlap between the reference info from the bbl file and the info from the S2 API.

This PR fixes that issue by augmenting our reference extractor to include text that appears in hyperlinks.