### PR TITLE
Update pipeline log messages: remove verbose messages; add timing messages

### DIFF
--- a/data-processing/common/commands/locate_entities.py
+++ b/data-processing/common/commands/locate_entities.py
@@ -13,14 +13,23 @@ from common.colorize_tex import ColorizedTex, colorize_entities
 from common.commands.base import ArxivBatchCommand
 from common.commands.compile_tex import save_compilation_result
 from common.commands.raster_pages import raster_pages
-from common.compile import (compile_tex, get_compiled_tex_files,
-                            get_last_autotex_compiler,
-                            get_last_colorized_entity_id)
+from common.compile import (
+    compile_tex,
+    get_compiled_tex_files,
+    get_last_autotex_compiler,
+    get_last_colorized_entity_id,
+)
 from common.diff_images import diff_images_in_raster_dirs
 from common.locate_entities import locate_entities
-from common.types import (ArxivId, ColorizationRecord, ColorizeOptions,
-                          FileContents, HueLocationInfo, RelativePath,
-                          SerializableEntity)
+from common.types import (
+    ArxivId,
+    ColorizationRecord,
+    ColorizeOptions,
+    FileContents,
+    HueLocationInfo,
+    RelativePath,
+    SerializableEntity,
+)
 
 
 @dataclass(frozen=True)
@@ -401,7 +410,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
                 )
                 if not raster_success:
                     logging.error(  # pylint: disable=logging-not-lazy
-                        "Failed to rasterize pages for %s iteration %d. The locations for entities "
+                        "Failed to rasterize pages for %s iteration %s. The locations for entities "
                         + "with IDs %s with not be detected.",
                         item.arxiv_id,
                         iteration_id,
@@ -410,7 +419,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
                     continue
 
                 logging.debug(
-                    "Attempting to diff rastered pages for paper %s iteration %d.",
+                    "Attempting to diff rastered pages for paper %s iteration %s.",
                     item.arxiv_id,
                     iteration_id,
                 )
@@ -418,7 +427,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
                     output_files, raster_output_dir, diffs_output_dir, item.arxiv_id,
                 )
                 logging.debug(
-                    "Finished diffing attempt for paper %s iteration %d. Success? %s.",
+                    "Finished diffing attempt for paper %s iteration %s. Success? %s.",
                     item.arxiv_id,
                     iteration_id,
                     diff_success,
@@ -426,7 +435,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
                 if not diff_success:
                     logging.error(  # pylint: disable=logging-not-lazy
                         "Failed to difference images of original and colorized versions of "
-                        + "papers %s in batch processing iteration %d. The locations for entities with IDs "
+                        + "papers %s in batch processing iteration %s. The locations for entities with IDs "
                         + "%s will not be detected.",
                         item.arxiv_id,
                         iteration_id,
@@ -436,7 +445,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
 
             # Locate the entities in the diffed images.
             logging.debug(
-                "Attempting to locate entities using image differences for paper %s iteration %d.",
+                "Attempting to locate entities using image differences for paper %s iteration %s.",
                 item.arxiv_id,
                 iteration_id,
             )
@@ -542,7 +551,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
                     to_process_alone.extend(batch)
 
             logging.debug(
-                "Finished attempt at locating entities with image diffs for paper %s iteration %d",
+                "Finished attempt at locating entities with image diffs for paper %s iteration %s.",
                 item.arxiv_id,
                 iteration_id,
             )

--- a/data-processing/common/commands/raster_pages.py
+++ b/data-processing/common/commands/raster_pages.py
@@ -115,18 +115,21 @@ def raster_pages(
         for arg in args
     ]
 
+    logging.debug(
+        "Attempting to raster pages for file %s.", resolved_compiled_file_path
+    )
     result = subprocess.run(
         args_resolved, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
     )
     if result.returncode == 0:
         logging.debug(
-            "Successfully rastered pages for file %s using command %s",
+            "Successfully rastered pages for file %s using command %s.",
             resolved_compiled_file_path,
             args_resolved,
         )
     else:
         logging.error(
-            "Error rastering file %s using command %s: (Stdout: %s), (Stderr: %s)",
+            "Error rastering file %s using command %s: (Stdout: %s), (Stderr: %s).",
             resolved_compiled_file_path,
             args_resolved,
             result.stdout,

--- a/data-processing/common/compile.py
+++ b/data-processing/common/compile.py
@@ -53,7 +53,7 @@ def compile_tex(sources_dir: str) -> CompilationResult:
     Compile TeX sources into PDFs. Requires running an external script to attempt to compile
     the TeX. See README.md for dependencies.
     """
-    logging.debug("Compiling sources in %s", sources_dir)
+    logging.debug("Compiling sources in %s.", sources_dir)
     _set_sources_dir_permissions(sources_dir)
 
     config = configparser.ConfigParser()
@@ -88,6 +88,12 @@ def compile_tex(sources_dir: str) -> CompilationResult:
             output_files.append(OutputFile("ps", postscript_filename))
         compiled_tex_files = get_compiled_tex_files_from_autotex_output(result.stdout)
         success = True
+
+    logging.debug(
+        "Finished compilation attempt for sources in %s. Success? %s.",
+        sources_dir,
+        success,
+    )
 
     return CompilationResult(
         success, compiled_tex_files, output_files, result.stdout, result.stderr

--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -75,12 +75,6 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
             most_similar_reference = None
             for reference in item.references:
                 similarity = ngram_sim(reference.title, bibitem.text)
-                logging.debug(
-                    "Computed similarity of %f between reference '%s' and bibitem text '%s'",
-                    similarity,
-                    reference.title,
-                    bibitem.text,
-                )
                 if similarity > SIMILARITY_THRESHOLD and similarity > max_similarity:
                     max_similarity = similarity
                     most_similar_reference = reference

--- a/data-processing/entities/symbols/commands/extract_symbols.py
+++ b/data-processing/entities/symbols/commands/extract_symbols.py
@@ -164,13 +164,7 @@ class ExtractSymbols(ArxivBatchCommand[ArxivId, List[EquationSymbols]]):
             symbols = equation_symbols.symbols
             error_message = equation_symbols.error_message
 
-            if success and symbols is not None:
-                logging.debug(
-                    "Successfully extracted %d symbols for equation %s.",
-                    len(symbols),
-                    equation,
-                )
-            else:
+            if not success or not symbols:
                 logging.warning(
                     "Could not parse equation %s. See logs in %s.",
                     equation,


### PR DESCRIPTION
I'm considering making updates to the pipeline to make it faster to process papers. To determine the effort required to speed up the pipeline, I'd like to collect more detailed timing information about key steps in the paper processing pipeline.

This PR adds log statements to the commands for locating entities that can be used to measure the time it takes to:

1. Insert color macros into the TeX
2. Compile the TeX
3. Raster the TeX to images
4. Difference the images
5. Locate entities in the image diffs

These steps will be performed up to thousands of times for a single paper, so strategic improvements to pipeline performance can be aided by knowing which one of these steps usually takes the longest.

Log statements are added both at the start and end of each of the steps above to make it possible for our log analysis scripts to measure the of that step as the difference in timestamps between the start and end log message.

I have also removed a couple of overly verbose log messages from the project which have never really served a purpose in helping me (or as far as I know, anyone else) debug.