### PR TITLE
Add API route to verify existence of a paper within ScholarPhi's DB

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -123,6 +123,36 @@ export const plugin = {
 
     server.route({
       method: "GET",
+      path: "papers/{s2Id}",
+      handler: async (request, h) => {
+        const s2Id = request.params.s2Id;
+        const exists = await dbConnection.checkPaper({ s2_id: s2Id });
+        return exists ? h.response().code(204) : h.response().code(404);
+      },
+      options: {
+        validate: {
+          params: validation.s2Id,
+        },
+      },
+    })
+
+    server.route({
+      method: "GET",
+      path: "papers/arxiv:{arxivId}",
+      handler: async (request, h) => {
+        const arxivId = request.params.arxivId;
+        const exists = await dbConnection.checkPaper({ arxiv_id: arxivId });
+        return exists ? h.response().code(204) : h.response().code(404);
+      },
+      options: {
+        validate: {
+          params: validation.arxivId,
+        },
+      },
+    });
+
+    server.route({
+      method: "GET",
       path: "papers/{s2Id}/entities",
       handler: (request) => {
         const s2Id = request.params.s2Id;

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -114,6 +114,12 @@ export class Connection {
     return { rows, offset, size, total };
   }
 
+  async checkPaper(paperSelector: PaperSelector): Promise<boolean> {
+    const rows = await this._knex("paper")
+      .where(paperSelector);
+    return rows.length > 0;
+  }
+
   async getLatestPaperDataVersion(paperSelector: PaperSelector): Promise<number | null> {
     const rows = await this._knex("version")
       .max("index")


### PR DESCRIPTION
Use case: S2 needs a way to determine whether ScholarPhi has data for a paper in order to display a link to read said paper with ScholarPhi.

I was originally going to use the /entities endpoint, but it returns far too much data when all I need is a simple boolean response. This endpoint responds with either a `204 No Content` if the paper exists (the status code itself is the answer to the request) or `404 Not Found` if it does not exist.