### PR TITLE
Add CORS origins so S2 webapp can hit ScholarPhi API

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -253,6 +253,9 @@ export const plugin = {
         return h.response({ version }).code(200);
       },
       options: {
+        cors: {
+          origin: ['*.semanticscholar.org', '*.allenai.org'],
+        },
         validate: {
           params: validation.arxivId,
         },

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -253,9 +253,6 @@ export const plugin = {
         return h.response({ version }).code(200);
       },
       options: {
-        cors: {
-          origin: ['*.semanticscholar.org', '*.allenai.org'],
-        },
         validate: {
           params: validation.arxivId,
         },

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -29,6 +29,9 @@ class ApiServer {
         request: ["error"],
       },
       routes: {
+        cors: {
+          origin: ['*.semanticscholar.org', '*.allenai.org'],
+        },
         validate: {
           failAction: this._debug ? debugFailAction : undefined,
         },

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -30,7 +30,7 @@ class ApiServer {
       },
       routes: {
         cors: {
-          origin: ['*'], // TODO: This is really insecure
+          origin: ['*.semanticscholar.org', '*.allenai.org', '*.allenai.org:8080'],
         },
         validate: {
           failAction: this._debug ? debugFailAction : undefined,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -30,7 +30,7 @@ class ApiServer {
       },
       routes: {
         cors: {
-          origin: ['*.semanticscholar.org', '*.allenai.org'],
+          origin: ['*'], // TODO: This is really insecure
         },
         validate: {
           failAction: this._debug ? debugFailAction : undefined,


### PR DESCRIPTION
This CORS config should allow the S2 webapp (when running either in a deployed instance or on a developer laptop) to make API requests to ScholarPhi.