### PR TITLE
Update computation of bounding box detection accuracy

### DIFF
--- a/data-processing/common/bounding_box.py
+++ b/data-processing/common/bounding_box.py
@@ -567,12 +567,12 @@ def compute_accuracy(
     actual: List[FrozenSet[FloatRectangle]],
     expected: List[FrozenSet[FloatRectangle]],
     minimum_iou: float = 0.5,
-) -> Tuple[float, float]:
+) -> Tuple[Optional[float], Optional[float], RegionMatches]:
 
     ious = iou_per_region(actual, expected, minimum_iou)
 
     count_found = len(ious)
-    precision = float(count_found) / len(actual)
-    recall = float(count_found) / len(expected)
+    precision = float(count_found) / len(actual) if len(actual) > 0 else None
+    recall = float(count_found) / len(expected) if len(expected) > 0 else None
 
-    return (precision, recall)
+    return (precision, recall, ious)

--- a/data-processing/common/bounding_box.py
+++ b/data-processing/common/bounding_box.py
@@ -564,8 +564,8 @@ def iou_per_region(
 
 
 def compute_accuracy(
-    actual: Iterable[FrozenSet[FloatRectangle]],
-    expected: Iterable[FrozenSet[FloatRectangle]],
+    actual: List[FrozenSet[FloatRectangle]],
+    expected: List[FrozenSet[FloatRectangle]],
     minimum_iou: float = 0.5,
 ) -> Tuple[float, float]:
 

--- a/data-processing/common/bounding_box.py
+++ b/data-processing/common/bounding_box.py
@@ -503,11 +503,14 @@ def iou(
     return intersection_area / union_area
 
 
+RegionMatches = Dict[Tuple[FrozenSet[FloatRectangle], FrozenSet[FloatRectangle]], float]
+
+
 def iou_per_region(
     regions: Iterable[FrozenSet[FloatRectangle]],
     other_regions: Iterable[FrozenSet[FloatRectangle]],
     minimum_iou: float = 0.5,
-) -> Dict[Tuple[FrozenSet[FloatRectangle], FrozenSet[FloatRectangle]], float]:
+) -> RegionMatches:
     """
     Match all regions in one set to regions in another set. Each rectangle set in
     'regions' can me matched to only one rectangle set in 'other_regions' and vice versa. This

--- a/data-processing/common/commands/compute_iou.py
+++ b/data-processing/common/commands/compute_iou.py
@@ -5,10 +5,14 @@ from dataclasses import dataclass
 from typing import Dict, FrozenSet, Iterator, List, Optional, Tuple
 
 from common import directories, file_utils
-from common.bounding_box import (RegionMatches, compute_accuracy, iou,
-                                 iou_per_region, sum_areas)
+from common.bounding_box import (
+    RegionMatches,
+    compute_accuracy,
+    iou,
+    iou_per_region,
+    sum_areas,
+)
 from common.commands.database import DatabaseReadCommand
-from common.models import BoundingBox as BoundingBoxModel
 from common.models import Entity as EntityModel
 from common.models import Paper
 from common.types import ArxivId, BoundingBox, FloatRectangle
@@ -140,19 +144,17 @@ class ComputeIou(DatabaseReadCommand[IouJob, IouResults]):
             # Load gold bounding boxes from the database.
             expected: RegionsByPageAndType = defaultdict(list)
             entity_models = (
-                EntityModel.select()
-                .join(Paper)
-                .join(BoundingBoxModel)
-                .where(Paper.arxiv_id == arxiv_id)
+                EntityModel.select().join(Paper).where(Paper.arxiv_id == arxiv_id)
             )
             for entity in entity_models:
+                print("Entity: ", entity.id)
                 bounding_boxes = [
                     BoundingBox(box.left, box.top, box.width, box.height, box.page)
                     for box in entity.bounding_boxes
                 ]
                 by_page = group_by_page(bounding_boxes)
                 for page, page_boxes in by_page.items():
-                    key = (entity.page, entity.type)
+                    key = (page, entity.type)
                     rectangles = frozenset(
                         [
                             FloatRectangle(b.left, b.top, b.width, b.height)
@@ -224,7 +226,7 @@ class ComputeIou(DatabaseReadCommand[IouJob, IouResults]):
 
         entity_iou_path = os.path.join(bounding_box_accuracies_path, "entity_ious.csv")
         for i, rect_set in enumerate(item.actual):
-            match_iou = 0.
+            match_iou = 0.0
             match = None
 
             for (region, other_region), pair_iou in result.matches.items():

--- a/data-processing/common/file_utils.py
+++ b/data-processing/common/file_utils.py
@@ -505,7 +505,7 @@ def load_locations(
     )
     if not os.path.exists(bounding_boxes_path):
         logging.warning(
-            "Could not find bounding boxes information entity of type %s for paper %s. Skipping.",
+            "Could not find bounding boxes information for entity of type %s for paper %s. Skipping.",
             entity_name,
             arxiv_id,
         )

--- a/data-processing/common/file_utils.py
+++ b/data-processing/common/file_utils.py
@@ -17,12 +17,27 @@ from typing import Any, Dict, Iterator, List, Optional, Type, TypeVar
 from common import directories
 from common.colorize_tex import EntityId
 from common.string import JournaledString
-from common.types import (ArxivId, BoundingBox, CompilationResult, Equation,
-                          EquationId, FileContents, HueIteration,
-                          HueLocationInfo, Path, SerializableChild,
-                          SerializableSymbol, SerializableSymbolToken,
-                          SerializableToken, Symbol, SymbolId, SymbolWithId,
-                          Token, TokenId)
+from common.types import (
+    ArxivId,
+    BoundingBox,
+    CompilationResult,
+    EntityLocationInfo,
+    Equation,
+    EquationId,
+    FileContents,
+    HueIteration,
+    HueLocationInfo,
+    Path,
+    SerializableChild,
+    SerializableSymbol,
+    SerializableSymbolToken,
+    SerializableToken,
+    Symbol,
+    SymbolId,
+    SymbolWithId,
+    Token,
+    TokenId,
+)
 
 Contents = str
 Encoding = str
@@ -497,7 +512,7 @@ def load_locations(
         )
         return None
 
-    for hue_info in load_from_csv(bounding_boxes_path, HueLocationInfo):
+    for hue_info in load_from_csv(bounding_boxes_path, EntityLocationInfo):
         box = BoundingBox(
             page=hue_info.page,
             left=hue_info.left,
@@ -510,10 +525,10 @@ def load_locations(
     return boxes_by_entity_id
 
 
-def load_citation_locations(
+def load_citation_fragment_locations(
     arxiv_id: ArxivId,
 ) -> Optional[Dict[EntityId, List[BoundingBox]]]:
-    return load_locations(arxiv_id, "citations")
+    return load_locations(arxiv_id, "citation-fragments")
 
 
 def load_equation_token_locations(

--- a/data-processing/common/file_utils.py
+++ b/data-processing/common/file_utils.py
@@ -25,7 +25,6 @@ from common.types import (
     Equation,
     EquationId,
     FileContents,
-    HueIteration,
     HueLocationInfo,
     Path,
     SerializableChild,

--- a/data-processing/common/make_digest.py
+++ b/data-processing/common/make_digest.py
@@ -2,8 +2,13 @@ import os
 from typing import Iterable, Optional
 
 from common import directories, file_utils
-from common.types import (ArxivId, EntityProcessingDigest, HueLocationInfo,
-                          PaperProcessingDigest, SerializableEntity)
+from common.types import (
+    ArxivId,
+    EntityLocationInfo,
+    EntityProcessingDigest,
+    PaperProcessingDigest,
+    SerializableEntity,
+)
 from scripts.pipelines import EntityPipeline
 
 
@@ -91,7 +96,7 @@ def count_hues_located(
         )
         if os.path.exists(hue_locations_path):
             num_hues_located = len(
-                list(file_utils.load_from_csv(hue_locations_path, HueLocationInfo))
+                list(file_utils.load_from_csv(hue_locations_path, EntityLocationInfo))
             )
 
     return num_hues_located

--- a/data-processing/common/models.py
+++ b/data-processing/common/models.py
@@ -152,7 +152,7 @@ class Entity(TimestampsMixin, OutputModel):
 
 class BoundingBox(TimestampsMixin, OutputModel):
 
-    entity = ForeignKeyField(Entity, on_delete="CASCADE")
+    entity = ForeignKeyField(Entity, on_delete="CASCADE", backref="bounding_boxes")
     source = TextField(index=True, default="tex-pipeline")
     page = IntegerField()
 

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -565,16 +565,10 @@ TokenLocations = Dict[TokenId, List[BoundingBox]]
 
 
 @dataclass(frozen=True)
-class CitationLocation(BoundingBox):
-    key: str
-    cluster_index: int
-
-
-@dataclass(frozen=True)
 class CitationData:
     arxiv_id: ArxivId
     s2_id: S2Id
-    citation_locations: Dict[str, Dict[int, Set[CitationLocation]]]
+    citation_locations: Dict[str, Dict[int, Set[EntityLocationInfo]]]
     key_s2_ids: Dict[str, str]
     s2_data: Dict[S2Id, SerializableReference]
 

--- a/data-processing/entities/citations/__init__.py
+++ b/data-processing/entities/citations/__init__.py
@@ -13,12 +13,12 @@ from .types import Bibitem
 
 directories.register("detected-citations")
 directories.register("bibitem-resolutions")
-directories.register("sources-with-colorized-citations")
-directories.register("compiled-sources-with-colorized-citations")
-directories.register("paper-images-with-colorized-citations")
-directories.register("diffed-images-with-colorized-citations")
+directories.register("sources-with-colorized-citation-fragments")
+directories.register("compiled-sources-with-colorized-citation-fragments")
+directories.register("paper-images-with-colorized-citation-fragments")
+directories.register("diffed-images-with-colorized-citation-fragments")
+directories.register("citation-fragments-locations")
 directories.register("citations-locations")
-directories.register("citation-cluster-locations")
 directories.register("sources-with-annotated-symbols")
 
 
@@ -26,7 +26,10 @@ commands: CommandList = [
     ExtractBibitems,
     ResolveBibitems,
     make_locate_entities_command(
-        "citations", DetectedEntityType=Bibitem, colorize_func=colorize_citations
+        entity_name="citation-fragments",
+        input_entity_name="citations",
+        DetectedEntityType=Bibitem,
+        colorize_func=colorize_citations,
     ),
     LocateCitations,
     UploadCitations,

--- a/data-processing/scripts/process.py
+++ b/data-processing/scripts/process.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 from common.commands.base import Command, CommandList
 from common.commands.compile_tex import CompileNormalizedTexSources, CompileTexSources
+from common.commands.compute_iou import ComputeIou
 from common.commands.fetch_arxiv_sources import FetchArxivSources
 from common.commands.fetch_new_arxiv_ids import FetchNewArxivIds
 from common.commands.fetch_s2_data import FetchS2Metadata
@@ -105,7 +106,7 @@ STORE_RESULTS_COMMANDS: CommandList = [
 ]
 
 EVALUATION_COMMANDS: CommandList = [
-    #     ComputeIou,
+    ComputeIou,
 ]
 
 ALL_COMMANDS = (

--- a/data-processing/tests/test_bounding_box.py
+++ b/data-processing/tests/test_bounding_box.py
@@ -230,6 +230,6 @@ def test_rectangle_precision_recall():
     # The threshold value is set to the level where rectangle 1 in 'expected' does not have a
     # a match in 'actual', and rectangle 2 in 'expected' only has a match if you consider
     # its overlap with *all* rectangles in 'actual'.
-    precision, recall = compute_accuracy(expected, actual, minimum_iou=0.5)
+    precision, recall, _ = compute_accuracy(expected, actual, minimum_iou=0.5)
     assert precision == 0.5
     assert recall == 0.5

--- a/data-processing/tests/test_bounding_box.py
+++ b/data-processing/tests/test_bounding_box.py
@@ -8,7 +8,6 @@ from common.bounding_box import (
     find_boxes_with_color,
     intersect,
     iou,
-    iou_per_rectangle,
     iou_per_region,
     subtract,
     subtract_multiple,
@@ -209,23 +208,6 @@ def fs(*rects: Rectangle) -> FrozenSet[Rectangle]:
     return frozenset(rects)
 
 
-def test_compute_iou_per_rectangle():
-    # There's a 10px-wide overlap between rect1 and rect2; the algorithm for IOU should use the
-    # union of the areas of the input rects.
-    rects = [
-        fs(Rectangle(0, 0, 20, 20)),
-        fs(Rectangle(10, 0, 30, 20)),
-        fs(Rectangle(40, 10, 10, 10), Rectangle(40, 0, 10, 10)),
-    ]
-    other_rects = [Rectangle(10, 0, 20, 20), Rectangle(35, 0, 20, 20)]
-    ious = iou_per_rectangle(rects, other_rects)
-    assert ious[fs(Rectangle(0, 0, 20, 20))] == float(10) / 30
-    assert ious[fs(Rectangle(10, 0, 30, 20))] == float(25) / 45
-    assert (
-        ious[fs(Rectangle(40, 10, 10, 10), Rectangle(40, 0, 10, 10))] == float(10) / 20
-    )
-
-
 def test_compute_iou_per_rectangle_set():
     regions = [
         fs(Rectangle(0, 0, 20, 20)),
@@ -244,7 +226,7 @@ def test_compute_iou_per_rectangle_set():
 
 def test_rectangle_precision_recall():
     expected = [fs(Rectangle(0, 0, 20, 20)), fs(Rectangle(10, 0, 30, 20))]
-    actual = [Rectangle(10, 0, 20, 20), Rectangle(35, 0, 20, 20)]
+    actual = [fs(Rectangle(10, 0, 20, 20)), fs(Rectangle(35, 0, 20, 20))]
     # The threshold value is set to the level where rectangle 1 in 'expected' does not have a
     # a match in 'actual', and rectangle 2 in 'expected' only has a match if you consider
     # its overlap with *all* rectangles in 'actual'.


### PR DESCRIPTION
This PR introduces revives scripts for computing the accuracy of the bounding boxes extracted by the pipeline.

Of particular note, the scripts for computing bounding box accuracy were extended to handle two special cases:

1. When bounding boxes in the gold set match multiple extracted bounding boxes---in this case the box in the gold set should probably only be matched to a single extracted bounding box to not overinflate the accuracy
2. When bounding boxes in the gold set should be clustered into groups (like with sentences), and matches should be determined based on whether a group of boxes in the gold set matches a group of extracted boxes.

The main change, then, is a function called `iou_per_region`. It finds the "ideal" match between two sets of groups of bounding boxes. Specifically, it:

1. Takes as input (a) a set of gold groups of bounding boxes and (b) a set of extracted groups of bounding boxes (each group corresponding to a sentence, a symbol, a citation, etc.)
2. Determines _all_ pairs from set (a) and set (b) that overlap more than a certain threshold
3. Solves a linear assignment problem to determine the maximum number of groups from set (a) that can be matched to those from set (b), without matching any box from one set to more than one from the other
4. Returns the IOU for the boxes between the two sets that were assigned to each other