### PR TITLE
Pipeline: Update default texlive_bin_path and comment in config.ini

### DIFF
--- a/data-processing/config.ini
+++ b/data-processing/config.ini
@@ -11,7 +11,10 @@
 # This directory should contain a 'texmf-dist' subdirectory.
 texlive_path = /usr/share/texlive/
 # This is the directory that contains the 'pdflatex' and 'latex' binaries.
-texlive_bin_path = /usr/bin/
+# It should also contain binaries for typical sytem utilities like 'mkdir' and 'sed'
+# in case LaTeX needs to call them on the fly during compilation, as is the case for
+# on-demand font generation with 'kpathsea'.
+texlive_bin_path = /usr/bin/:/bin
 
 # Commands for rastering TeX output files into images.
 # Each key is the extension for a type of TeX output (e.g., 'pdf', 'ps').


### PR DESCRIPTION
I was observing problems with the pipeline compiling TeX files that used specialized fonts (e.g., `ifsym`). It turns out that if these fonts do not already exist in the TeXLive distribution, the LaTeX compiler with automatically generate them from spec files. However, to do so, it needs to run common Unix commands like `sed` and `mkdir`. If AutoTeX does not know where to find these utilities, font generation will fail, as will compilation of that document.

Therefore, to be more robust, those who run the pipeline should edit the `texlive_bin_path` variable to also provide a search path to the common system Unix utilities.