### PR TITLE
Pipeline: Make LaTeX coloring macros and error checking more robust

### DIFF
--- a/data-processing/common/diff_images.py
+++ b/data-processing/common/diff_images.py
@@ -24,7 +24,7 @@ def diff_images_in_raster_dirs(
     compilation_output_files: List[OutputFile],
     comparison_rasters_base_dir: RelativePath,
     diffs_output_dir: RelativePath,
-    arxiv_id: ArxivId
+    arxiv_id: ArxivId,
 ) -> bool:
     """
     Diff images from a modified rendering of TeX files versus the original rendering.
@@ -44,6 +44,17 @@ def diff_images_in_raster_dirs(
     for output_file in compilation_output_files:
         relative_file_path = output_file.path
         original_images_path = os.path.join(original_images_dir, relative_file_path)
+        if not os.path.exists(original_images_path):
+            logging.warning(  # pylint: disable=logging-not-lazy
+                "Could not find expected directory of images from the compiled original sources "
+                + "at %s. One cause of this error is when the original sources have multiple main "
+                + "TeX files merged into one synthetic file, and the modified sources fail to "
+                + "compile, resulting in a different main output file. Check the modified sources "
+                + "for paper %s for errors.",
+                original_images_path,
+                arxiv_id,
+            )
+            return False
         for img_name in os.listdir(original_images_path):
             original_img_path = os.path.join(original_images_path, img_name)
             modified_img_path = os.path.join(

--- a/data-processing/common/normalize_tex.py
+++ b/data-processing/common/normalize_tex.py
@@ -106,7 +106,9 @@ def expand_tex(
     # In a specific sample of about 120 conference papers, only 5 had '\include' macros, yet
     # many more had '\input' commands). Only 1 used an '\include' macro to read in text.
     # The rest of the files used '\include' macros to include macros and usepackage statements.
-    include_patterns = [
+    # XXX(andrewhead): The 'includes' patterns are currently disabled because the TeX that is
+    # being inserted in their place is incorrect (i.e., it causes compilation errors).
+    include_patterns: List[Pattern] = [
         # Pattern("include_braces", r"\\include\s*{([^}]+)}"),
         # Pattern("include", r"\\include\s+(\S+)"),
     ]

--- a/data-processing/common/normalize_tex.py
+++ b/data-processing/common/normalize_tex.py
@@ -107,8 +107,8 @@ def expand_tex(
     # many more had '\input' commands). Only 1 used an '\include' macro to read in text.
     # The rest of the files used '\include' macros to include macros and usepackage statements.
     include_patterns = [
-        Pattern("include_braces", r"\\include\s*{([^}]+)}"),
-        Pattern("include", r"\\include\s+(\S+)"),
+        # Pattern("include_braces", r"\\include\s*{([^}]+)}"),
+        # Pattern("include", r"\\include\s+(\S+)"),
     ]
     endinput_pattern = Pattern("endinput", r"\\endinput( |\t|\b|\{.*?\})")
     patterns = input_patterns + include_patterns + [endinput_pattern]

--- a/data-processing/resources/01-macros.tex
+++ b/data-processing/resources/01-macros.tex
@@ -1,15 +1,8 @@
 % Convenience commands for checking if command is defined or not. Work in TeX and LaTeX
-\def\scholarifundefined#1#2{%
-\expandafter\ifx\csname #1\endcsname\relax%
-#2%
-\fi%
-}
-\def\scholarifdefined#1#2{%
-\expandafter\ifx\csname #1\endcsname\relax%
-\else%
-#2%
-\fi%
-}
+% If possible, check for definitions using e-TeX's '\ifcsname' command, as it does not
+% have the side effect of defining an undefined command as '\relax'. See
+% the discussion about this side effect here https://tex.stackexchange.com/a/164197/198728.
+\expandafter\ifx\csname ifcsname\endcsname\relax%
 \def\scholarifdefinedelse#1#2#3{%
 \expandafter\ifx\csname #1\endcsname\relax%
 #3%
@@ -17,6 +10,23 @@
 #2%
 \fi%
 }
+\else
+\def\scholarifdefinedelse#1#2#3{%
+\ifcsname#1\endcsname%
+#2%
+\else%
+#3%
+\fi%
+}
+\fi
+
+\def\scholarifundefined#1#2{%
+\scholarifdefinedelse{#1}{}{#2}%
+}
+\def\scholarifdefined#1#2{%
+\scholarifdefinedelse{#1}{#2}{}%
+}
+
 
 % Define names of color drivers
 % Once the color package is imported in the '02x' macro files, you can check to

--- a/data-processing/resources/03-load-color-commands.tex
+++ b/data-processing/resources/03-load-color-commands.tex
@@ -165,11 +165,12 @@ scholarcolor@\scholar@current@citation@key%
 }}%
 }%
 \scholar@wrap@citecolor{}%
+\scholarifdefined{hypersetup}{%
 \let\scholar@inner@hypersetup\hypersetup%
 \def\hypersetup#1{%
 \scholar@inner@hypersetup{#1}%
 \scholar@wrap@citecolor{}%
-}%
+}}%
 \message{Defined S2 LaTeX coloring commands.}%
 }}%
 

--- a/data-processing/tests/test_normalize_tex.py
+++ b/data-processing/tests/test_normalize_tex.py
@@ -155,15 +155,17 @@ def test_unify_tex_with_input_with_spaces_in_path():
         assert expand_tex(tex_dir, "main.tex") == "Hello world!"
 
 
-def test_unify_tex_with_include():
-    with TemporaryDirectory() as tex_dir:
-        create_temp_files(
-            tex_dir, {"main.tex": r"\include{other}", "other.tex": "Hello world!"},
-        )
-        expanded = expand_tex(tex_dir, "main.tex")
-        assert "Hello world!" in expanded
-        assert r"\clearpage" in expanded
-        assert r"\@input{other.aux}" in expanded
+# XXX(andrewhead): This test is temporarily disabled while the expansion of
+# include commands is fixed. See the implementation of the 'normalize_tex' function for details.
+# def test_unify_tex_with_include():
+#     with TemporaryDirectory() as tex_dir:
+#         create_temp_files(
+#             tex_dir, {"main.tex": r"\include{other}", "other.tex": "Hello world!"},
+#         )
+#         expanded = expand_tex(tex_dir, "main.tex")
+#         assert "Hello world!" in expanded
+#         assert r"\clearpage" in expanded
+#         assert r"\@input{other.aux}" in expanded
 
 
 def test_unify_tex_with_include_ignore_non_tex_files_with_same_filename():


### PR DESCRIPTION
This PR contains two fixes:

First, the code for the pipeline commands is made robust to strange errors that arise when a paper is compiled from multiple main files (which is in fact possible for arXiv papers).

Second, the coloring macros have been made slightly more robust. To support both TeX and LaTeX, the coloring macros have conditional logic that depends on our custom macro `\scholarifdefined...`, which can be used to see what coloring commands are available in the environment, and find out other useful information.

It turns out that the way we were checking if a command was defined had the side effect of _defining_ that command to be `\relax` if it was not yet defined. In most cases, this did not matter. For the supplemental material (`supp.tex`) of paper 1712.05055, it did matter. I believe what was happening was that the style file had a check for whether hypersetup was defined. Typically, it is not. Our code defined it (albeit to a no-op value). This changed the behavior of the style file, and thefore the appearance of the document.

This fix will not fix the problem for _all_ Tex documents, as it only works for papers that are compiled with an e-TeX-based backend. It worked for this paper, so I am hopeful it will work for many others.