### PR TITLE
TeX: Fix bug in TeX expansion when main file ends in '\endinput'

### DIFF
--- a/data-processing/common/normalize_tex.py
+++ b/data-processing/common/normalize_tex.py
@@ -135,9 +135,9 @@ def expand_tex(
     # Scan file for input macros, expanding them.
     for match in scan_tex(tex, patterns):
 
-        # If a file is being read as input, and the '\endinput' macro is reached, end output
-        # at the end of the line that \endinput appears on. See the TeXBook for a description of
-        # the how \endinput is expanded.
+        # If a file is being read and the '\endinput' macro is reached, end output at the end of
+        # the line that \endinput appears on. See the TeXBook for a description of the how
+        # \endinput macro is handled.
         if match.pattern is endinput_pattern:
             endinput = EndInput(start=match.start, end=match.end)
             replacements.append(endinput)

--- a/data-processing/common/normalize_tex.py
+++ b/data-processing/common/normalize_tex.py
@@ -136,22 +136,23 @@ def expand_tex(
     for match in scan_tex(tex, patterns):
 
         # If a file is being read as input, and the '\endinput' macro is reached, end output
-        # the end of the line that \endinput appears on. See the TeXBook for a description of
+        # at the end of the line that \endinput appears on. See the TeXBook for a description of
         # the how \endinput is expanded.
-        if is_input and match.pattern is endinput_pattern:
-
+        if match.pattern is endinput_pattern:
             endinput = EndInput(start=match.start, end=match.end)
             replacements.append(endinput)
             endinputs.append(endinput)
 
             # Find the newline after the \endinput, after which no more inputs should be expanded
             # and the file should be truncated.
-            end_of_line = re.compile("$", flags=re.MULTILINE)
-            end_of_line_match = end_of_line.search(tex, pos=match.end)
-            if end_of_line_match:
-                end_file_at = end_of_line_match.start()
-                continue
+            if end_file_at is None:
+                end_of_line = re.compile("$", flags=re.MULTILINE)
+                end_of_line_match = end_of_line.search(tex, pos=match.end)
+                if end_of_line_match:
+                    end_file_at = end_of_line_match.start()
+                    continue
 
+        # For input macros (e.g., '\input', '\include', ...)
         # Re-run the pattern against the matched text to extract the path to the file
         # that is meant to be included.
         match_with_groups = re.match(match.pattern.regex, match.text)
@@ -204,13 +205,14 @@ def expand_tex(
 
         replacements.append(Expansion(start=match.start, end=match.end, tex=input_tex))
 
-    # Apply the expansions to the TeX.
+    # Truncate the TeX file after the end of a line where the first '\endinput' macro appears.
     expanded = tex
     if end_file_at is not None:
         expanded = expanded[:end_file_at]
 
+    # Apply the expansions to the TeX.
     for replacement in reversed(replacements):
-        if end_file_at is not None and replacement.start > end_file_at:
+        if end_file_at is not None and replacement.start >= end_file_at:
             continue
         if isinstance(replacement, EndInput):
             expanded = expanded[: replacement.start] + "" + expanded[replacement.end :]


### PR DESCRIPTION
This PR fixes a bug in TeX file expansion.

TeX files can contain a control sequence called `\endinput` which stops TeX from continuing to read that file. This can be used, for instance, to store extra TeX at the end of a file that will not be included in the document (see another use case in this [StackExchange post](https://tex.stackexchange.com/a/23127/198728)).

Our code for expanding a TeX file that include input macros correctly handled the `\endinput` macro if it appeared in a file input from the main file of the TeX project, but it did not handle `\endinput` at all when it appeared in the main file of a TeX project. This led to a bug where `\endinput` was getting processed as an `\input` macro, and our code tried to get the arguments to it as if it was an `\input` command (which obviously failed).

The fix was to handle `\endinput` the same way in both the main file and the input file---stop reading once it is reached.

The validity of this fix has been verified by running the unit tests, whose behavior has remained unchanged, and by re-running the pipeline on paper 2009.14237 and seeing normalization succeed.