### PR TITLE
UI: Disable declutter by default; only enable citation glosses and sy…

### DIFF
--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -110,6 +110,9 @@ const PRESETS: Preset[] = [
     key: "demo",
     primerInstructionsEnabled: false,
     useDefinitionsForDiagramLabels: true,
+    termGlossesEnabled: true,
+    declutterEnabled: true,
+    equationDiagramsEnabled: true,
   },
   {
     key: "sab",
@@ -122,72 +125,6 @@ const PRESETS: Preset[] = [
     key: "sab-lite",
     symbolUnderlineMethod: "top-level-symbols",
     equationDiagramsEnabled: false,
-  },
-  {
-    key: "study",
-    primerInstructionsEnabled: false,
-    citationGlossesEnabled: false,
-    termGlossesEnabled: true,
-    symbolUnderlineMethod: "defined-symbols",
-    useDefinitionsForDiagramLabels: true,
-  },
-  /*
-   * No interactivity for terms and symbols.
-   */
-  {
-    key: "ca",
-    annotationHintsEnabled: false,
-    annotationInteractionEnabled: false,
-    primerPageEnabled: false,
-    equationDiagramsEnabled: false,
-    glossesEnabled: false,
-    declutterEnabled: false,
-  },
-  /*
-   * Show declutter, not glosses.
-   */
-  {
-    key: "cc",
-    annotationInteractionEnabled: true,
-    primerPageEnabled: false,
-    glossesEnabled: false,
-    equationDiagramsEnabled: false,
-    declutterEnabled: true,
-  },
-  /*
-   * Enable all of the interactive features.
-   */
-  {
-    key: "cd",
-    annotationInteractionEnabled: true,
-    primerPageEnabled: true,
-    glossesEnabled: true,
-    equationDiagramsEnabled: true,
-    declutterEnabled: true,
-  },
-  {
-    key: "focused-reading",
-    annotationInteractionEnabled: true,
-    primerPageEnabled: true,
-    glossesEnabled: true,
-    equationDiagramsEnabled: true,
-    declutterEnabled: true,
-  },
-  {
-    key: "tp",
-    initialFocus: "94185",
-  },
-  {
-    key: "ta",
-    initialFocus: "94247",
-  },
-  {
-    key: "tb",
-    initialFocus: "94110",
-  },
-  {
-    key: "tc",
-    initialFocus: "94159",
   },
 ];
 
@@ -205,12 +142,12 @@ export function getSettings(presets?: string[]) {
     glossStyle: "tooltip",
     textSelectionMenuEnabled: false,
     citationGlossesEnabled: true,
-    termGlossesEnabled: true,
+    termGlossesEnabled: false,
     symbolUnderlineMethod: "defined-symbols",
     symbolSearchEnabled: true,
-    declutterEnabled: true,
+    declutterEnabled: false,
     definitionPreviewEnabled: false,
-    equationDiagramsEnabled: true,
+    equationDiagramsEnabled: false,
     useDefinitionsForDiagramLabels: false,
     entityCreationEnabled: false,
     entityEditingEnabled: false,


### PR DESCRIPTION
This PR addresses issue https://github.com/allenai/scholar/issues/26218 (cc @aschokking)

It accomplishes two goals:

1. It disables the 'declutter' symbol interaction by default. As it turns out, we already had a flag in the user interface for turning on and off 'declutter.' This PR modifies the default settings such that the only features enabled are symbol search and citation abstracts.

2. It removes out some of the old settings presets that were used exclusively for our formal usability study.

A GIF showing proof of successful implementation is forthcoming.