### PR TITLE
Pipeline: Several bugfixes to support ScholarPhi paper

### DIFF
--- a/data-processing/common/commands/locate_entities.py
+++ b/data-processing/common/commands/locate_entities.py
@@ -629,9 +629,12 @@ def get_last_colorized_entity(
         )
         return None
 
-    with open(original_autogen_log_path) as file_:
+    # If TeX can process data that is not utf-8, then that non-utf-8 data can also be printed
+    # out to the AutoTeX log. Therefore, when reading the AutoTeX log, the files need to be opened
+    # in a way that is permissive of non-utf-8 data.
+    with open(original_autogen_log_path, errors="surrogateescape") as file_:
         original_autogen_log = file_.read()
-    with open(new_autogen_log_path) as file_:
+    with open(new_autogen_log_path, errors="surrogateescape") as file_:
         new_autogen_log = file_.read()
 
     # Get the name of the TeX compiler that successfully compiled the original TeX.

--- a/data-processing/entities/citations/extractor.py
+++ b/data-processing/entities/citations/extractor.py
@@ -50,7 +50,7 @@ class BibitemExtractor:
             (
                 r"\\bibitem"  # 'bibitem' control sequence
                 + r"(?:\s*|%.*?$)*"  # space or comments
-                + r"\[[^\]].*?\]"  # label
+                + r"\[[^\]]*?\]"  # label
                 + r"(?:\s*|%.*?$)*"  # space or comments
                 + r"\{([^}]*?)\}"  # key (capture)
             ),

--- a/data-processing/resources/03-load-color-commands.tex
+++ b/data-processing/resources/03-load-color-commands.tex
@@ -156,7 +156,12 @@
 % is redefined both as this macro is loading, and whenever \hypersetup is called
 % in the middle of a TeX file (which redefines \@citecolor by default).
 \def\scholar@wrap@citecolor{%
+% Only define inner citecolor macro once. Because this \scholar@wrap@citecolor setup
+% macro can (and will) be called multiple times, defining the inner citecolor command
+% to be the citecolor command that wraps it would cause a recursive loop.
+\scholarifundefined{scholar@inner@citecolor}{%
 \let\scholar@inner@citecolor\@citecolor
+}%
 \def\@citecolor{%
 \scholarifdefinedelse{scholarcolor@\scholar@current@citation@key}{%
 scholarcolor@\scholar@current@citation@key%

--- a/data-processing/tests/test_parse_tex.py
+++ b/data-processing/tests/test_parse_tex.py
@@ -458,11 +458,24 @@ def test_extract_bibitem_include_hyperref_contents():
 
 
 def test_extract_bibitem_wrapping_key():
-    tex = "\n".join([r"\bibitem[label]%", r"    {key}", r"    token"])
+    tex = "\n".join(
+        [
+            r"\bibitem[\protect\citeauthoryear{Grossman, Chevalier, and Kazi}{Grossman",
+            r"  et~al\mbox{.}}{2015}]%",
+            r"        {ref:grossman2015your}",
+            r"\bibfield{author}{\bibinfo{person}{Tovi Grossman}, \bibinfo{person}{Fanny",
+            r"  Chevalier}, {and} \bibinfo{person}{Rubaiat~Habib Kazi}.}",
+            r"  \bibinfo{year}{2015}\natexlab{}.",
+            r"\newblock \showarticletitle{Your Paper is Dead! Bringing Life to Research",
+            r"  Articles with Animated Figures}. In \bibinfo{booktitle}{\emph{\confchi}}.",
+            r"  \bibinfo{publisher}{ACM}, \bibinfo{pages}{461--475}.",
+            r"\newblock.",
+        ]
+    )
     extractor = BibitemExtractor()
     bibitems = list(extractor.parse(tex))
     assert len(bibitems) == 1
-    assert "token" in bibitems[0].text
+    assert "Animated" in bibitems[0].text
 
 
 def test_extract_macro():

--- a/data-processing/tests/test_parse_tex.py
+++ b/data-processing/tests/test_parse_tex.py
@@ -458,24 +458,19 @@ def test_extract_bibitem_include_hyperref_contents():
 
 
 def test_extract_bibitem_wrapping_key():
-    tex = "\n".join(
-        [
-            r"\bibitem[\protect\citeauthoryear{Grossman, Chevalier, and Kazi}{Grossman",
-            r"  et~al\mbox{.}}{2015}]%",
-            r"        {ref:grossman2015your}",
-            r"\bibfield{author}{\bibinfo{person}{Tovi Grossman}, \bibinfo{person}{Fanny",
-            r"  Chevalier}, {and} \bibinfo{person}{Rubaiat~Habib Kazi}.}",
-            r"  \bibinfo{year}{2015}\natexlab{}.",
-            r"\newblock \showarticletitle{Your Paper is Dead! Bringing Life to Research",
-            r"  Articles with Animated Figures}. In \bibinfo{booktitle}{\emph{\confchi}}.",
-            r"  \bibinfo{publisher}{ACM}, \bibinfo{pages}{461--475}.",
-            r"\newblock.",
-        ]
-    )
+    tex = "\n".join([r"\bibitem[label]%", r"    {key}", r"    token"])
     extractor = BibitemExtractor()
     bibitems = list(extractor.parse(tex))
     assert len(bibitems) == 1
-    assert "Animated" in bibitems[0].text
+    assert "token" in bibitems[0].text
+
+
+def test_extract_bibitem_with_brackets_in_label():
+    tex = "\n".join([r"\bibitem[label{[]}]{key}", r"token"])
+    extractor = BibitemExtractor()
+    bibitems = list(extractor.parse(tex))
+    assert len(bibitems) == 1
+    assert "token" in bibitems[0].text
 
 
 def test_extract_macro():

--- a/data-processing/tests/test_parse_tex.py
+++ b/data-processing/tests/test_parse_tex.py
@@ -1,6 +1,11 @@
-from common.parse_tex import (BeginDocumentExtractor, DocumentclassExtractor,
-                              EquationExtractor, MacroExtractor,
-                              PhraseExtractor, extract_plaintext)
+from common.parse_tex import (
+    BeginDocumentExtractor,
+    DocumentclassExtractor,
+    EquationExtractor,
+    MacroExtractor,
+    PhraseExtractor,
+    extract_plaintext,
+)
 from common.types import MacroDefinition
 from entities.citations.extractor import BibitemExtractor
 from entities.sentences.extractor import SentenceExtractor
@@ -450,6 +455,14 @@ def test_extract_bibitem_include_hyperref_contents():
     bibitems = list(extractor.parse(tex))
     assert len(bibitems) == 1
     assert bibitems[0].text == "token1 token2"
+
+
+def test_extract_bibitem_wrapping_key():
+    tex = "\n".join([r"\bibitem[label]%", r"    {key}", r"    token"])
+    extractor = BibitemExtractor()
+    bibitems = list(extractor.parse(tex))
+    assert len(bibitems) == 1
+    assert "token" in bibitems[0].text
 
 
 def test_extract_macro():


### PR DESCRIPTION
Several changes were needed to make the ScholarPhi pipeline robust enough to handle the [ScholarPhi paper](https://arxiv.org/abs/2009.14237). Namely:

1. A bug was found in the citation color macros where a coloring macro was calling itself recursively. That has now been fixed (`03-load-color-commands.tex`)

2. TeX logs can apparently contain non-utf-8 characters. So the logs needed to be loaded in a way that was tolerant to unexpected non-utf-8 characters (`locate_entities.tex`)

3. The bibliography entries for this paper were written idiosyncratically---often there was a newline between the `\bibitem` macro and the `{...}` curly braces in which the key for the reference was written. This was confusing our code that parsed out reference keys from the bibliography. This has since been fixed (see `extractor.py` and `test_parse_tex.py`).

The following GIF shows citation interactions working for the ScholarPhi paper in a local version of the app:

![citations_working](https://user-images.githubusercontent.com/2358524/105109665-d833a680-5a71-11eb-8217-e159da4e269b.gif)