### PR TITLE
Make /version API aware of entity data

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,8 @@
   "author": "Andrew Head <andrewhead@allenai.org>",
   "license": "Apache-2.0",
   "jest": {
-    "preset": "ts-jest"
+    "preset": "ts-jest",
+    "testPathIgnorePatterns": ["<rootDir>/build/", "<rootDir>/node_modules/"]
   },
   "devDependencies": {
     "@types/hapi__hapi": "^18.2.5",

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -247,7 +247,7 @@ export const plugin = {
         const paperSelector = { arxiv_id: request.params.arxivId };
         const version = await dbConnection.getLatestProcessedArxivVersion(paperSelector);
         const entityCount = await dbConnection.getPaperEntityCount(paperSelector);
-        if (!version || (!entityCount || entityCount?.count === 0)) {
+        if (!version || !entityCount) {
           // We don't have version info for this ID, or no entities were extracted.
           return h.response().code(404);
         }

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -247,7 +247,7 @@ export const plugin = {
         const paperSelector = { arxiv_id: request.params.arxivId };
         const version = await dbConnection.getLatestProcessedArxivVersion(paperSelector);
         const entityCount = await dbConnection.getPaperEntityCount(paperSelector);
-        if (!version || entityCount?.count === 0) {
+        if (!version || (!entityCount || entityCount?.count === 0)) {
           // We don't have version info for this ID, or no entities were extracted.
           return h.response().code(404);
         }

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -244,10 +244,11 @@ export const plugin = {
       method: "GET",
       path: "papers/arxiv:{arxivId}/version",
       handler: async (request, h) => {
-        const arxivId = request.params.arxivId;
-        const version = await dbConnection.getLatestProcessedArxivVersion({ arxiv_id: arxivId });
-        if (!version) {
-          // We don't have version info for this ID
+        const paperSelector = { arxiv_id: request.params.arxivId };
+        const version = await dbConnection.getLatestProcessedArxivVersion(paperSelector);
+        const entityCount = await dbConnection.getPaperEntityCount(paperSelector);
+        if (!version || entityCount?.count === 0) {
+          // We don't have version info for this ID, or no entities were extracted.
           return h.response().code(404);
         }
         return h.response({ version }).code(200);

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -116,7 +116,8 @@ export class Connection {
 
   async getPaperEntityCount(paperSelector: PaperSelector): Promise<{paper: PaperSelector, count: number} | null> {
     const idField = isS2Selector(paperSelector) ? 'p.s2_id' : 'p.arxiv_id';
-    const idValue = isS2Selector(paperSelector) ? paperSelector.s2_id : paperSelector.arxiv_id;
+    const idValue = isS2Selector(paperSelector) ? paperSelector.s2_id : `${paperSelector.arxiv_id}%`;
+    const whereClause = `${idField} ${isS2Selector(paperSelector) ? '=' : 'ilike'} ?`
     const response = await this._knex.raw<{ rows: {count: number, id: string}[] }>(`
       select count(e.*), ${idField}
       from paper p
@@ -126,7 +127,7 @@ export class Connection {
         from entity
         group by paper_id order by paper_id
       ) as maximum on maximum.paper_id = e.paper_id
-      where e.version = maximum.max_version and ${idField} = ?
+      where e.version = maximum.max_version and ${whereClause}
       group by p.s2_id
     `, [idValue]);
     if (response.rows.length > 0) {

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -114,6 +114,30 @@ export class Connection {
     return { rows, offset, size, total };
   }
 
+  async getPaperEntityCount(paperSelector: PaperSelector): Promise<{paper: PaperSelector, count: number} | null> {
+    const idField = isS2Selector(paperSelector) ? 'p.s2_id' : 'p.arxiv_id';
+    const idValue = isS2Selector(paperSelector) ? paperSelector.s2_id : paperSelector.arxiv_id;
+    const response = await this._knex.raw<{ rows: {count: number, id: string}[] }>(`
+      select count(e.*), ${idField}
+      from paper p
+      join entity e on e.paper_id = p.s2_id
+      join (
+        select paper_id, max(version) as max_version
+        from entity
+        group by paper_id order by paper_id
+      ) as maximum on maximum.paper_id = e.paper_id
+      where e.version = maximum.max_version and ${idField} = ?
+      group by p.s2_id
+    `, [idValue]);
+    if (response.rows.length > 0) {
+      return {
+        paper: paperSelector,
+        count: response.rows[0].count,
+      };
+    }
+    return null;
+  }
+
   async checkPaper(paperSelector: PaperSelector): Promise<boolean> {
     const rows = await this._knex("paper")
       .where(paperSelector);

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -114,7 +114,7 @@ export class Connection {
     return { rows, offset, size, total };
   }
 
-  async getPaperEntityCount(paperSelector: PaperSelector): Promise<{paper: PaperSelector, count: number} | null> {
+  async getPaperEntityCount(paperSelector: PaperSelector): Promise<number | null> {
     const idField = isS2Selector(paperSelector) ? 'p.s2_id' : 'p.arxiv_id';
     const idValue = isS2Selector(paperSelector) ? paperSelector.s2_id : `${paperSelector.arxiv_id}%`;
     const whereClause = `${idField} ${isS2Selector(paperSelector) ? '=' : 'ilike'} ?`
@@ -125,16 +125,13 @@ export class Connection {
       join (
         select paper_id, max(version) as max_version
         from entity
-        group by paper_id order by paper_id
+        group by paper_id
       ) as maximum on maximum.paper_id = e.paper_id
       where e.version = maximum.max_version and ${whereClause}
       group by p.s2_id
     `, [idValue]);
     if (response.rows.length > 0) {
-      return {
-        paper: paperSelector,
-        count: response.rows[0].count,
-      };
+      return response.rows[0].count;
     }
     return null;
   }

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -957,4 +957,81 @@ describe("API", () => {
       expect(await knex("entitydata").select()).toHaveLength(0);
     });
   });
+
+  describe("GET /api/v0/papers/arxiv:{arxivId}/version", () => {
+    test("paper with entity data", async () => {
+      await knex("paper").insert({
+        s2_id: "s2id",
+        arxiv_id: "1111.1111",
+      } as PaperRow);
+      await knex("version").insert({
+        id: 1,
+        paper_id: "s2id",
+        index: 0,
+      } as VersionRow);
+      await knex.batchInsert("entity", [
+        {
+          id: 1,
+          paper_id: "s2id",
+          version: 0,
+          type: "unknown",
+          source: "test",
+        },
+      ] as EntityRow[]);
+      await knex.batchInsert("boundingbox", [
+        {
+          entity_id: 1,
+          source: "test",
+          page: 0,
+          left: 0,
+          top: 0,
+          width: 0.1,
+          height: 0.05,
+        },
+      ] as BoundingBoxRow[]);
+      await knex.batchInsert("entitydata", [
+        {
+          entity_id: 1,
+          source: "test",
+          key: "key",
+          value: "value",
+          item_type: "string",
+          of_list: false,
+          relation_type: null,
+        },
+      ] as EntityDataRow[]);
+
+      const response = await server.inject({
+        method: "get",
+        url: "/api/v0/papers/arxiv:1111.1111/version",
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result).toEqual({ version: 0 });
+    });
+
+    test("paper with no entity data", async () => {
+      await knex("paper").insert({
+        s2_id: "s2id",
+        arxiv_id: "1111.1111",
+      } as PaperRow);
+      const response = await server.inject({
+        method: "get",
+        url: "/api/v0/papers/arxiv:1111.1111/version",
+      });
+
+      expect(response.statusCode).toEqual(404);
+      expect(response.result).toBeNull();
+    });
+
+    test("unknown paper", async () => {
+      const response = await server.inject({
+        method: "get",
+        url: "/api/v0/papers/arxiv:1111.1111/version",
+      });
+
+      expect(response.statusCode).toEqual(404);
+      expect(response.result).toBeNull();
+    });
+  });
 });

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -962,7 +962,7 @@ describe("API", () => {
     test("paper with entity data", async () => {
       await knex("paper").insert({
         s2_id: "s2id",
-        arxiv_id: "1111.1111",
+        arxiv_id: "1111.1111v1",
       } as PaperRow);
       await knex("version").insert({
         id: 1,
@@ -1007,17 +1007,17 @@ describe("API", () => {
       });
 
       expect(response.statusCode).toEqual(200);
-      expect(response.result).toEqual({ version: 0 });
+      expect(response.result).toEqual({ version: 1 });
     });
 
     test("paper with no entity data", async () => {
       await knex("paper").insert({
         s2_id: "s2id",
-        arxiv_id: "1111.1111",
+        arxiv_id: "1111.1112v1",
       } as PaperRow);
       const response = await server.inject({
         method: "get",
-        url: "/api/v0/papers/arxiv:1111.1111/version",
+        url: "/api/v0/papers/arxiv:1111.1112/version",
       });
 
       expect(response.statusCode).toEqual(404);
@@ -1027,7 +1027,7 @@ describe("API", () => {
     test("unknown paper", async () => {
       const response = await server.inject({
         method: "get",
-        url: "/api/v0/papers/arxiv:1111.1111/version",
+        url: "/api/v0/papers/arxiv:1111.1113/version",
       });
 
       expect(response.statusCode).toEqual(404);

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -978,28 +978,6 @@ describe("API", () => {
           source: "test",
         },
       ] as EntityRow[]);
-      await knex.batchInsert("boundingbox", [
-        {
-          entity_id: 1,
-          source: "test",
-          page: 0,
-          left: 0,
-          top: 0,
-          width: 0.1,
-          height: 0.05,
-        },
-      ] as BoundingBoxRow[]);
-      await knex.batchInsert("entitydata", [
-        {
-          entity_id: 1,
-          source: "test",
-          key: "key",
-          value: "value",
-          item_type: "string",
-          of_list: false,
-          relation_type: null,
-        },
-      ] as EntityDataRow[]);
 
       const response = await server.inject({
         method: "get",


### PR DESCRIPTION
S2 uses this API to determine whether or not to display the Semantic Reader button on the PDP, and to prevent the button from displaying for papers that don't have any extracted entities, this change ensures we only report back with version data if we also have extracted entities for that paper.