### PR TITLE
UI: Add guards to sorting / display logic when an entity has no bounding boxes

### DIFF
--- a/ui/src/components/preview/SymbolPreview.tsx
+++ b/ui/src/components/preview/SymbolPreview.tsx
@@ -1,8 +1,7 @@
-import PaperClipping from "./PaperClipping";
-import { Sentence, Symbol } from "../../api/types";
-
 import { PDFDocumentProxy } from "pdfjs-dist";
 import React from "react";
+import { Sentence, Symbol } from "../../api/types";
+import PaperClipping from "./PaperClipping";
 
 interface Props {
   pdfDocument: PDFDocumentProxy;
@@ -39,6 +38,13 @@ export class SymbolPreview extends React.PureComponent<Props> {
 
   render() {
     const { symbol } = this.props;
+    if (symbol.attributes.bounding_boxes.length === 0) {
+      return (
+        <div className="symbol-preview empty">
+          There are no locations associated with this symbol.
+        </div>
+      );
+    }
     return (
       <div ref={(ref) => (this.element = ref)} className="symbol-preview">
         <PaperClipping

--- a/ui/src/selectors/entity.ts
+++ b/ui/src/selectors/entity.ts
@@ -1,5 +1,4 @@
 import { defaultMemoize } from "reselect";
-import { Entities } from "../state";
 import {
   BoundingBox,
   Entity,
@@ -11,6 +10,7 @@ import {
   Symbol,
   Term,
 } from "../api/types";
+import { Entities } from "../state";
 import { Rectangle } from "../types/ui";
 
 export function selectedEntityType(
@@ -211,6 +211,12 @@ export const orderByPosition = defaultMemoize(
       const symbol1TopBox = symbol1Boxes.sort(compareBoxes)[0];
       const symbol2Boxes = entities.byId[sId2].attributes.bounding_boxes;
       const symbol2TopBox = symbol2Boxes.sort(compareBoxes)[0];
+      if (symbol1Boxes.length === 0) {
+        return -1;
+      }
+      if (symbol2Boxes.length === 0) {
+        return 1;
+      }
       return compareBoxes(symbol1TopBox, symbol2TopBox);
     });
     return sorted;


### PR DESCRIPTION
It sometimes happens that the pipeline uploads entities that have no bounding boxes at all. While most of the UI code has guards to check whether an entity has some bounding boxes before attempting to do something with those boxes, some of it does not. This leads to exceptions.

This PR introduces two small fixes in the form of guards in the UI code that check for the presence of bounding boxes for an entity before attempting to do something with those bounding boxes. In particular, the guards appear before:

1. Sorting two entities based on the position of the bounding boxes
2. Rendering a preview of a symbol

Guard #1 has been tested to fix the following exception for paper 2101.05042v1 in a local version of the UI with the fixes incorporated:

![image](https://user-images.githubusercontent.com/2358524/105201484-cac00000-5af5-11eb-84fe-83b88af8b35e.png)

Clicking on a symbol in that paper now no longer results in this exception.

cc @kyleclo, who authored the first version of this fix.