### PR TITLE
Rename ScholarPhi -> Semantic Reader in public-facing places

### DIFF
--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -77,7 +77,7 @@ async function getPaper(s2Id: string, apiKey?: string): Promise<Paper | undefine
 
   const conf: AxiosRequestConfig = {
     headers: {
-      'user-agent': 'ScholarPhi API Client (https://scholarphi.semanticscholar.org)'
+      'user-agent': 'Semantic Reader API Client (https://scholarphi.semanticscholar.org)'
     }
   };
   if (apiKey) {

--- a/ui/public/papers/index.html
+++ b/ui/public/papers/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html>
     <head>
-        <title>All Papers — Semantic Scholar Interactive Reader</title>
+        <title>Semantic Reader - All Papers</title>
         <link rel="icon" href="../images/favicon.png">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     </head>

--- a/ui/public/viewer.html
+++ b/ui/public/viewer.html
@@ -32,7 +32,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Interactive Reader</title>
+    <title>Semantic Reader</title>
 
 
     <link rel="icon" href="images/favicon.png" sizes="32x32">

--- a/ui/src/components/primer/PrimerPage.tsx
+++ b/ui/src/components/primer/PrimerPage.tsx
@@ -103,7 +103,7 @@ class PrimerPage extends React.PureComponent<Props> {
                 parts of a paper?
               </p>
               <p>
-                This reading application, called <b>ScholarPhi</b>, explains
+                This reading application, called <b>Semantic Reader</b>, explains
                 confusing things in papers. You can click on citations, symbols,
                 and terms to look up explanations of them. Anything that has a{" "}
                 <span style={{ borderBottom: "1px dotted" }}>
@@ -140,7 +140,7 @@ class PrimerPage extends React.PureComponent<Props> {
                 Berkeley. Contact the researchers if you have any questions.
               </p>
               <p>
-                If you have feedback on how to improve ScholarPhi or want to report a bug, please join our Slack channel <a href="https://join.slack.com/share/zt-kzpbfz5x-5xVGrzxORdkdNI_RIjS52A">#s2-scholarphi-users</a>.
+                If you have feedback on how to improve Semantic Reader or want to report a bug, please join our Slack channel <a href="https://join.slack.com/share/zt-kzpbfz5x-5xVGrzxORdkdNI_RIjS52A">#s2-scholarphi-users</a>.
               </p>
               <hr />
               <p className="primer-page__header">Reading settings</p>


### PR DESCRIPTION
Ref https://github.com/allenai/scholar/issues/26407

Since "Semantic Reader" is the official name for the app, this changes some publicly-facing parts of the code to use the new name. It also makes me think we might want to rename the Slack channel while we're at it.