### PR TITLE
Symbol parsing cleanup

### DIFF
--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -206,6 +206,7 @@ export interface Symbol extends BaseEntity {
 
 export interface SymbolAttributes extends BaseEntityAttributes {
   tex: string | null;
+  type: "identifier" | "function" | "operator";
   mathml: string | null;
   mathml_near_matches: string[];
   is_definition: boolean | null;

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -112,8 +112,9 @@ attributes = attributes
       {
         is: "symbol",
         then: Joi.object().keys({
-          mathml: stringAttribute,
           tex: stringAttribute,
+          type: stringAttribute,
+          mathml: stringAttribute,
           nicknames: stringListAttribute,
           diagram_label: stringAttribute,
           is_definition: booleanAttribute,

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -373,12 +373,7 @@ class SerializableToken(SerializableEntity, Token):
 
 
 NodeType = Literal[
-    "identifier",
-    "function",
-    "left-parens",
-    "right-parens",
-    "definition-operator",
-    "operator",
+    "identifier", "function", "definition-operator", "operator",
 ]
 
 

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -372,6 +372,10 @@ class SerializableToken(SerializableEntity, Token):
     " See 'relative_start'. "
 
 
+# Type of symbol. If a new symbol type is added, then several other places in the larger
+# project need to be changed: (1) the symbol attributes type in the API and UI and (2) the UI code
+# that renders symbol annotations, which needs to be told which symbol types should be rendered,
+# and which types should not.
 NodeType = Literal[
     "identifier", "function", "definition-operator", "operator",
 ]

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -372,10 +372,21 @@ class SerializableToken(SerializableEntity, Token):
     " See 'relative_start'. "
 
 
+NodeType = Literal[
+    "identifier",
+    "function",
+    "left-parens",
+    "right-parens",
+    "definition-operator",
+    "operator",
+]
+
+
 @dataclass(frozen=True)
 class SerializableSymbol(SerializableEntity, SymbolId):
     equation: str
     mathml: str
+    type_: NodeType
     is_definition: bool
     """
     Whether this appearance of the symbol is a definition of the symbol.

--- a/data-processing/entities/symbols/commands/extract_symbols.py
+++ b/data-processing/entities/symbols/commands/extract_symbols.py
@@ -227,6 +227,7 @@ class ExtractSymbols(ArxivBatchCommand[ArxivId, List[EquationSymbols]]):
                         tex=symbol_tex,
                         context_tex=context_tex,
                         mathml=str(symbol.element),
+                        type_=symbol.type_,
                         is_definition=symbol.defined or False,
                         relative_start=symbol.start,
                         relative_end=symbol.end,

--- a/data-processing/entities/symbols/upload.py
+++ b/data-processing/entities/symbols/upload.py
@@ -171,6 +171,7 @@ def upload_symbols(
             "tex": f"${symbol.tex}$",
             "tex_start": symbol.start,
             "tex_end": symbol.end,
+            "type": symbol.type_,
             "mathml": symbol.mathml,
             "mathml_near_matches": [m.matching_mathml for m in matches[symbol.mathml]],
             "snippets": other_context_texs,

--- a/data-processing/tests/mathml-fragments/delta_a_d_b.xml
+++ b/data-processing/tests/mathml-fragments/delta_a_d_b.xml
@@ -1,5 +1,5 @@
 <mrow>
-    <mi mathvariant="normal" s2:start="0" s2:end="9">∂</mi>
+    <mi s2:start="0" s2:end="9">∂</mi>
     <mi s2:start="9" s2:end="10">a</mi>
     <mi s2:start="11" s2:end="12">d</mi>
     <mi s2:start="12" s2:end="13">b</mi>

--- a/data-processing/tests/mathml-fragments/dot.xml
+++ b/data-processing/tests/mathml-fragments/dot.xml
@@ -1,0 +1,1 @@
+<mi s2:start="0" s2:end="1" s2:index="0">.</mi>

--- a/data-processing/tests/mathml-fragments/forall.xml
+++ b/data-processing/tests/mathml-fragments/forall.xml
@@ -1,4 +1,4 @@
 <mrow>
-    <mi mathvariant="normal" s2:start="0" s2:end="8">∀</mi>
+    <mi s2:start="0" s2:end="8">∀</mi>
     <mi s2:start="8" s2:end="9">x</mi>
 </mrow>

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -199,11 +199,11 @@ def test_detect_function_declaration():
     ), "function tokens should not include semicolons"
 
     child_symbols = symbol.child_symbols
-    assert len(child_symbols) == 6
+    assert len(child_symbols) == 8
     assert str(child_symbols[0].element) == "<mi>p</mi>"
-    assert str(child_symbols[1].element) == "<mi>x</mi>"
-    assert str(child_symbols[3].element) == "<mi>θ</mi>"
-    assert str(child_symbols[5].element) == "<mi>y</mi>"
+    assert str(child_symbols[2].element) == "<mi>x</mi>"
+    assert str(child_symbols[4].element) == "<mi>θ</mi>"
+    assert str(child_symbols[6].element) == "<mi>y</mi>"
 
 
 def test_detect_definition_of_function():

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -206,6 +206,7 @@ export interface Symbol extends BaseEntity {
 
 export interface SymbolAttributes extends BaseEntityAttributes {
   tex: string | null;
+  type: "identifier" | "function" | "operator";
   mathml: string | null;
   mathml_near_matches: string[];
   is_definition: boolean | null;

--- a/ui/src/components/control/EntityCreationToolbar.tsx
+++ b/ui/src/components/control/EntityCreationToolbar.tsx
@@ -92,6 +92,7 @@ export function createCreateEntityDataWithBoxes(
     data.attributes = {
       ...data.attributes,
       mathml: null,
+      type: "identifier",
       tex: text ? `$${text}$` : null,
       nicknames: [],
       diagram_label: null,

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -316,6 +316,14 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
             );
           } else if (isSymbol(entity)) {
             /*
+             * Only show annotations for identifiers and functions (i.e., not operators).
+             */
+            const ANNOTATED_SYMBOL_TYPES = ["identifier", "function"];
+            if (ANNOTATED_SYMBOL_TYPES.indexOf(entity.attributes.type) === -1) {
+              return null;
+            }
+
+            /*
              * If the symbol appears in a selected equation, don't render it; the
              * equation diagram provides its own targets to click.
              */

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -316,7 +316,8 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
             );
           } else if (isSymbol(entity)) {
             /*
-             * Only show annotations for identifiers and functions (i.e., not operators).
+             * Only show annotations for identifiers and functions (i.e., not operators). In
+             * the future, this filter could be exposed in the admin control panel.
              */
             const ANNOTATED_SYMBOL_TYPES = ["identifier", "function"];
             if (ANNOTATED_SYMBOL_TYPES.indexOf(entity.attributes.type) === -1) {


### PR DESCRIPTION
This PR contributes two changes.

1. Detect operator symbols (in case we eventually want to show explanations for them too)
2. Identify function symbols earlier in the pipeline---i.e., in an earlier stage in which the MathML for an equation is cleaned, rather than a later stage where that MathML is parsed for symbols. This may seem not useful, though it is a cleanup that will make it easier for me to make some other symbol segmentation improvements soon.

Because operator symbols will now be uploaded to the database, we need a way to filter them out of the UI until we decide we want to show them. Therefore, there are changes in the API and UI:

* API: extend the symbol attributes type to have a `type` field, which can be set to "identifier", "function", or "operator
* UI: only render annotations for symbols that are of type "identifier" or "function"