### PR TITLE
Outlier detection

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,10 @@
   "license": "Apache-2.0",
   "jest": {
     "preset": "ts-jest",
-    "testPathIgnorePatterns": ["<rootDir>/build/", "<rootDir>/node_modules/"]
+    "testPathIgnorePatterns": [
+      "<rootDir>/build/",
+      "<rootDir>/node_modules/"
+    ]
   },
   "devDependencies": {
     "@types/hapi__hapi": "^18.2.5",

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -263,6 +263,7 @@ export class Connection {
         version: entityRow.version,
         source: entityRow.source,
         bounding_boxes: boundingBoxes,
+        tags: attributes.tags || []
       },
       relationships: {
         ...relationships,

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -107,6 +107,7 @@ describe("API", () => {
                   height: 0.05,
                 },
               ],
+              tags: [],
             },
             relationships: {},
           },
@@ -159,6 +160,7 @@ describe("API", () => {
           version: 0,
           bounding_boxes: [],
           paper_id: "citation_paper_id",
+          tags: [],
         },
         relationships: {},
       } as Entity);
@@ -276,6 +278,7 @@ describe("API", () => {
           source: "test",
           version: 0,
           bounding_boxes: [],
+          tags: [],
           mathml: "<math></math>",
           mathml_near_matches: [
             "<math><mi>x</mi></math>",
@@ -367,6 +370,7 @@ describe("API", () => {
           source: "test",
           version: 0,
           bounding_boxes: [],
+          tags: [],
           text: "Sentence <symbol>.",
           tex: "Sentence $x$.",
           tex_start: 0,
@@ -405,6 +409,7 @@ describe("API", () => {
                 height: 0.05,
               },
             ],
+            tags: [],
           },
           relationships: {},
         },
@@ -479,6 +484,7 @@ describe("API", () => {
                 height: 0.05,
               },
             ],
+            tags: [],
           },
           relationships: {
             UNEXPECTED_RELATIONSHIP: { id: "1", type: "unknown" },
@@ -523,6 +529,7 @@ describe("API", () => {
               height: 0.05,
             },
           ],
+          tags: [],
         },
         relationships: {},
       };

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -156,7 +156,8 @@ export interface EntityCreatePayload {
 
 export interface EntityCreateData {
   type: string;
-  attributes: Omit<BaseEntityAttributes, "version"> & GenericAttributes;
+  attributes: Omit<BaseEntityAttributes, "version" | "tags"> &
+    GenericAttributes;
   relationships: GenericRelationships;
 }
 

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -13,10 +13,10 @@
  */
 
 export interface Paginated<T> {
-    rows: T[];
-    offset: number;
-    size: number;
-    total: number;
+  rows: T[];
+  offset: number;
+  size: number;
+  total: number;
 }
 
 export interface PaperIdWithEntityCounts {
@@ -95,6 +95,18 @@ export interface BaseEntityAttributes {
   version: number;
   source: string;
   bounding_boxes: BoundingBox[];
+  /**
+   * Additional data for this entity in the form of arbitrary strings. For instance, there could be
+   * a tag for a term entity conveying whether it is a 'key term'. As another example, and entity
+   * can be tagged as having irregular bounding boxes, so it should be hidden.
+   *
+   * For stable attributes of entities, they should be added as new named properties on the entity
+   * attributes types, instead of being stored as a tag. This is because it helps type-checking and
+   * code completion be more precise. That said, adding tags to store entity attributes is suitable
+   * when prototyping new features, as it allows the data to be changed in the database without
+   * continually updating these types.
+   */
+  tags: string[];
 }
 
 /**
@@ -277,11 +289,6 @@ export interface TermAttributes extends BaseEntityAttributes {
    * Additional passages that help explain what this term means.
    */
   snippets: string[];
-  /**
-   * Additional metadata for this term. For instance, one tag could be whether a term has been
-   * identified as a 'key term', to indicate that the term should be displayed in a special way.
-   */
-  tags: string[];
 }
 
 export interface TermRelationships {

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -119,6 +119,7 @@ export const BASE_ENTITY_ATTRIBUTE_KEYS = [
   "version",
   "source",
   "bounding_boxes",
+  "tags",
 ];
 
 /**

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -65,6 +65,7 @@ export let attributes = Joi.object({
    */
   source: Joi.string().required(),
   bounding_boxes: Joi.array().items(boundingBox),
+  tags: Joi.array().items(Joi.string()),
 });
 
 /**

--- a/data-processing/entities/symbols/upload.py
+++ b/data-processing/entities/symbols/upload.py
@@ -132,10 +132,6 @@ def upload_symbols(
             for l in localized_entity.locations
         ]
 
-        # TODO(andrewhead): move this filtering condition into 'parse_equation'
-        if symbol.tex in ["$|$", "|"]:
-            continue
-
         # Get context and formula of the symbol, and other matching ones.
         symbol_context = symbol_contexts.get(sid(symbol))
         matching_contexts = mathml_contexts.get(symbol.mathml, [])
@@ -159,8 +155,17 @@ def upload_symbols(
         # Package up data for the symbol.
         tags: List[str] = []
         MAX_BOX_HEIGHT = 0.1
-        if any(b.height > MAX_BOX_HEIGHT for b in boxes):
-            tags.append("large")
+        for b in boxes:
+            if b.height > MAX_BOX_HEIGHT:
+                logging.debug(  # pylint: disable=logging-not-lazy
+                    "Detected large bounding box for symbol with height %f for entity %s of paper "
+                    + "%s. Entity will be given a tag indicating it is unexpectedly large.",
+                    b.height,
+                    f"{localized_entity.entity.tex_path}-{localized_entity.entity.id_}",
+                    arxiv_id,
+                )
+                tags.append("large")
+                break
 
         data: EntityData = {
             "tex": f"${symbol.tex}$",

--- a/data-processing/entities/symbols/upload.py
+++ b/data-processing/entities/symbols/upload.py
@@ -157,6 +157,11 @@ def upload_symbols(
                 other_formula_ids.append(equation_id)
 
         # Package up data for the symbol.
+        tags: List[str] = []
+        MAX_BOX_HEIGHT = 0.1
+        if any(b.height > MAX_BOX_HEIGHT for b in boxes):
+            tags.append("large")
+
         data: EntityData = {
             "tex": f"${symbol.tex}$",
             "tex_start": symbol.start,
@@ -166,6 +171,7 @@ def upload_symbols(
             "snippets": other_context_texs,
             "defining_formulas": other_formula_texs,
             "is_definition": symbol.is_definition or False,
+            "tags": tags,
         }
 
         # Create links between this symbol, its sentence, and related symbols.

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -156,7 +156,8 @@ export interface EntityCreatePayload {
 
 export interface EntityCreateData {
   type: string;
-  attributes: Omit<BaseEntityAttributes, "version"> & GenericAttributes;
+  attributes: Omit<BaseEntityAttributes, "version" | "tags"> &
+    GenericAttributes;
   relationships: GenericRelationships;
 }
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -119,6 +119,7 @@ export const BASE_ENTITY_ATTRIBUTE_KEYS = [
   "version",
   "source",
   "bounding_boxes",
+  "tags",
 ];
 
 /**

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -12,6 +12,25 @@
  * into other projects, all of the types are available to the client code.
  */
 
+export interface Paginated<T> {
+  rows: T[];
+  offset: number;
+  size: number;
+  total: number;
+}
+
+export interface PaperIdWithEntityCounts {
+  s2_id: string;
+  arxiv_id?: string;
+  version: number;
+  symbol_count: number;
+  citation_count: number;
+  sentence_count: number;
+  term_count: number;
+  equation_count: number;
+  entity_count: number;
+}
+
 /**
  * Format of returned papers loosely follows that for the S2 API:
  * https://api.semanticscholar.org/
@@ -24,6 +43,17 @@ export interface Paper {
   url: string;
   venue: string;
   year: number | null;
+  influentialCitationCount?: number;
+  citationVelocity?: number;
+}
+
+export interface PaperWithEntityCounts extends PaperIdWithEntityCounts {
+  abstract?: string;
+  authors?: Author[];
+  title?: string;
+  url?: string;
+  venue?: string;
+  year?: number | null;
   influentialCitationCount?: number;
   citationVelocity?: number;
 }
@@ -65,6 +95,18 @@ export interface BaseEntityAttributes {
   version: number;
   source: string;
   bounding_boxes: BoundingBox[];
+  /**
+   * Additional data for this entity in the form of arbitrary strings. For instance, there could be
+   * a tag for a term entity conveying whether it is a 'key term'. As another example, and entity
+   * can be tagged as having irregular bounding boxes, so it should be hidden.
+   *
+   * For stable attributes of entities, they should be added as new named properties on the entity
+   * attributes types, instead of being stored as a tag. This is because it helps type-checking and
+   * code completion be more precise. That said, adding tags to store entity attributes is suitable
+   * when prototyping new features, as it allows the data to be changed in the database without
+   * continually updating these types.
+   */
+  tags: string[];
 }
 
 /**
@@ -247,11 +289,6 @@ export interface TermAttributes extends BaseEntityAttributes {
    * Additional passages that help explain what this term means.
    */
   snippets: string[];
-  /**
-   * Additional metadata for this term. For instance, one tag could be whether a term has been
-   * identified as a 'key term', to indicate that the term should be displayed in a special way.
-   */
-  tags: string[];
 }
 
 export interface TermRelationships {
@@ -339,36 +376,6 @@ export interface BoundingBox {
   top: number;
   width: number;
   height: number;
-}
-
-export interface Paginated<T> {
-    rows: T[];
-    offset: number;
-    size: number;
-    total: number;
-}
-
-export interface PaperIdWithEntityCounts {
-  s2_id: string;
-  arxiv_id?: string;
-  version: number;
-  symbol_count: number;
-  citation_count: number;
-  sentence_count: number;
-  term_count: number;
-  equation_count: number;
-  entity_count: number;
-}
-
-export interface PaperWithEntityCounts extends PaperIdWithEntityCounts {
-  abstract?: string;
-  authors?: Author[];
-  title?: string;
-  url?: string;
-  venue?: string;
-  year?: number | null;
-  influentialCitationCount?: number;
-  citationVelocity?: number;
 }
 
 /**

--- a/ui/src/components/control/EntityCreationToolbar.tsx
+++ b/ui/src/components/control/EntityCreationToolbar.tsx
@@ -1,4 +1,11 @@
-import { Entities, KnownEntityType, Pages } from "../../state";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
+import classNames from "classnames";
+import React from "react";
 import {
   BoundingBox,
   CitationAttributes,
@@ -11,16 +18,8 @@ import {
   TermAttributes,
   TermRelationships,
 } from "../../api/types";
+import { Entities, KnownEntityType, Pages } from "../../state";
 import * as uiUtils from "../../utils/ui";
-
-import Button from "@material-ui/core/Button";
-import Card from "@material-ui/core/Card";
-import FormControl from "@material-ui/core/FormControl";
-import InputLabel from "@material-ui/core/InputLabel";
-import MenuItem from "@material-ui/core/MenuItem";
-import Select from "@material-ui/core/Select";
-import classNames from "classnames";
-import React from "react";
 
 interface Props {
   className?: string;
@@ -74,12 +73,11 @@ export function createCreateEntityDataWithBoxes(
       ...data.attributes,
       name: text || null,
       term_type: null,
-      tags: [],
       definitions: [],
       definition_texs: [],
       sources: [],
       snippets: [],
-    } as Omit<TermAttributes, "version">;
+    } as Omit<TermAttributes, "version" | "tags">;
     data.relationships = {
       sentence: { type: "sentence", id: null },
       definition_sentences: [],
@@ -103,7 +101,7 @@ export function createCreateEntityDataWithBoxes(
       passages: [],
       mathml_near_matches: [],
       snippets: [],
-    } as Omit<SymbolAttributes, "version">;
+    } as Omit<SymbolAttributes, "version" | "tags">;
     data.relationships = {
       sentence: { type: "sentence", id: null },
       equation: { type: "equation", id: null },

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -1,11 +1,5 @@
-import CitationGloss from "../entity/citation/CitationGloss";
-import { DrawerContentType } from "../drawer/Drawer";
-import EntityAnnotation from "./EntityAnnotation";
-import * as selectors from "../../selectors";
-import { GlossStyle } from "../../settings";
-import SimpleSymbolGloss from "./SimpleSymbolGloss";
-import SimpleTermGloss from "./SimpleTermGloss";
-import { Entities, PaperId, Papers, UserLibrary } from "../../state";
+import classNames from "classnames";
+import React from "react";
 import {
   Entity,
   isCitation,
@@ -14,11 +8,16 @@ import {
   isSymbol,
   isTerm,
 } from "../../api/types";
+import * as selectors from "../../selectors";
+import { GlossStyle } from "../../settings";
+import { Entities, PaperId, Papers, UserLibrary } from "../../state";
 import { PDFPageView } from "../../types/pdfjs-viewer";
 import * as uiUtils from "../../utils/ui";
-
-import classNames from "classnames";
-import React from "react";
+import { DrawerContentType } from "../drawer/Drawer";
+import CitationGloss from "../entity/citation/CitationGloss";
+import EntityAnnotation from "./EntityAnnotation";
+import SimpleSymbolGloss from "./SimpleSymbolGloss";
+import SimpleTermGloss from "./SimpleTermGloss";
 
 export type SymbolUnderlineMethod = "top-level-symbols" | "defined-symbols";
 
@@ -195,6 +194,13 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
             (box) => box.page === pageNumber
           );
           if (boundingBoxes.length === 0) {
+            return null;
+          }
+
+          /*
+           * Do not show abnormally large entities.
+           */
+          if (entity.attributes.tags.indexOf("large") !== -1) {
             return null;
           }
 


### PR DESCRIPTION
See scholar repo issue https://github.com/allenai/scholar/issues/26282

This PR includes three changes to support filtering out bounding boxes with overly large bounding boxes:

1. It detects very large bounding boxes for symbols in the pipeline scripts (`upload.py`)
2. It adds a field called `tags` to all entities that can contain arbitrary tags (in this case to support the `"large"` tag for entities with very large bounding boxes)
3. It excludes all entities with the "large" tag from being rendered in the UI. 

The detection of large bounding boxes in the `upload.py` script is an alternative to doing so with the SQL maintenance script that was first proposed in https://github.com/allenai/scholarphi-pipeline/pull/27.