### PR TITLE
Pipeline: save space by deleting directories of compiled sources and …

### DIFF
--- a/data-processing/common/commands/locate_entities.py
+++ b/data-processing/common/commands/locate_entities.py
@@ -90,18 +90,11 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
         )
         parser.add_argument(
             "--keep-intermediate-files",
-            actionn="store_true",
+            action="store_true",
             help=(
-                "This command can consume gigabytes of storage. For each batch of entities, "
-                + "this command creates two copies of the source directory (one of which is "
-                + "compiled), and two sets of images (one which contains raster of the pages "
-                + "and one which contains differences of thos rasters against raster of the "
-                + "original paper). While the storage footprint of one batch is kilobytes "
-                + "or megabytes, this creates gigabytes across hundreds of batches. By default, "
-                + "these files are deleted after each batch to reduce the likelihood that "
-                + "the machine will run out of storage while processing a paper. It is left "
-                + "as an option for debugging purposes, i.e., if you wish to inspect how "
-                + "the TeX is colorized, TeX compilation logs, and rasters."
+                "Whether to keep intermediate files (sources, compilation results, page rasters) "
+                + "generated for each batch of entities processed. The default is to delete "
+                + "these files. See the argument documentation in 'run_pipeline' for more context."
             ),
         )
 


### PR DESCRIPTION
Addresses https://github.com/allenai/scholar/issues/26111

Machines that the pipeline runs on frequently run out of space, particularly for papers with lots of symbols. This PR seeks to remove the major source of out-of-space errors---namely, the creation of many copies of the TeX source directories and rastered images from a paper.

By default, the pipeline now deletes copies of TeX source directories and page rasters as soon as it is done using them. Now, at any given time, there should be only one set of copies of TeX sources and rastered images.

The reason all of these files were generated and stored in the first place was to aid with debugging of the pipeline. To allow us to continue debugging the pipeline, a flag `--keep-intermediate-files` has been added. When set, the copies of the TeX sources and the page rasters will not be deleted, so they can be inspected during debugging.