### PR TITLE
Pipeline: Make sentences optional for symbol detection

### DIFF
--- a/data-processing/entities/symbols/__init__.py
+++ b/data-processing/entities/symbols/__init__.py
@@ -143,6 +143,10 @@ def make_digest(_: str, arxiv_id: ArxivId) -> EntityProcessingDigest:
 
 
 symbols_pipeline = EntityPipeline(
-    "symbols", commands, depends_on=["equations", "sentences"], make_digest=make_digest,
+    "symbols",
+    commands,
+    depends_on=["equations"],
+    optional_depends_on=["sentences"],
+    make_digest=make_digest,
 )
 register_entity_pipeline(symbols_pipeline)


### PR DESCRIPTION
Due to two on-going efforts, it is currently not useful for us to require sentences to be detected when symbols are detected.

First, we are considering swapping out the sentence-detection backend with one that does not require parsing of LaTeX.

Second, we are currently focusing on improving the pipeline's ability to detect symbols without the 'declutter' interaction, which means that sentence information is not used.

This PR decouples sentence detection from symbol detection, so that we can test out the detection of symbols in the deployed pipeline without also spending compute time on detecting sentences.