### PR TITLE
Symbol extraction improvements: merging with scripts and font formats

### DIFF
--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -137,7 +137,7 @@ def repair_operator_tags(element: Tag) -> None:
     if element.name != "mi":
         return
 
-    if element.text in ["∀", "∃", "|", "∥", ".", "/", "%"]:
+    if element.text in ["∀", "∃", "|", "∥", "∣", ".", "/", "%"]:
         operator = clone_element(element)
         operator.name = "mo"
         element.replace_with(operator)
@@ -732,7 +732,7 @@ class MathMlElementMerger:
         # Here come the context-sensitive rules:
         # 1. Letters can be merged into any sequence of elements before them that starts with a
         #    a letter. This allows tokens to be merged into (target letter is shown in
-        #    <angled brackets> identifiers like "r2<d>2", but not constant multiplications like
+        #    <angled brackets>) identifiers like "r2<d>2", but not constant multiplications like
         #   "4<x>", which should be split into two symbols.
         if element.name == "mi":
             return bool(self.to_merge[0].name == "mi")
@@ -740,7 +740,11 @@ class MathMlElementMerger:
         # 3. Numbers can be merged into numbers before them, extending an identifier, or making
         #    a number with multiple digits.
         if element.name == "mn":
-            return True
+            return last_element.name in ["mi", "mn"]
+        # 4. Operators can be merged into operators that appear just before them to form multi-
+        #    symbol operators, like '++', '//', etc.
+        if element.name == "mo":
+            return last_element.name == "mo"
 
         return False
 

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -137,7 +137,7 @@ def repair_operator_tags(element: Tag) -> None:
     if element.name != "mi":
         return
 
-    if element.text in ["∀", "∃", "|", "∥", "."]:
+    if element.text in ["∀", "∃", "|", "∥", ".", "/", "%"]:
         operator = clone_element(element)
         operator.name = "mo"
         element.replace_with(operator)

--- a/data-processing/tests/mathml-fragments/bold_relu.xml
+++ b/data-processing/tests/mathml-fragments/bold_relu.xml
@@ -1,0 +1,6 @@
+<mrow s2:start="0" s2:end="13" s2:index="4">
+    <mi mathvariant="bold" s2:start="8" s2:end="9" s2:index="0">R</mi>
+    <mi mathvariant="bold" s2:start="9" s2:end="10" s2:index="1">e</mi>
+    <mi mathvariant="bold" s2:start="10" s2:end="11" s2:index="2">L</mi>
+    <mi mathvariant="bold" s2:start="11" s2:end="12" s2:index="3">U</mi>
+</mrow>

--- a/data-processing/tests/mathml-fragments/double_bar.xml
+++ b/data-processing/tests/mathml-fragments/double_bar.xml
@@ -1,4 +1,4 @@
 <mrow>
-    <mi mathvariant="normal" s2:start="0" s2:end="1" s2:index="0">∣</mi>
-    <mi mathvariant="normal" s2:start="1" s2:end="2" s2:index="1">∣</mi>
+    <mi s2:start="0" s2:end="1" s2:index="0">∣</mi>
+    <mi s2:start="1" s2:end="2" s2:index="1">∣</mi>
 </mrow>

--- a/data-processing/tests/mathml-fragments/double_bar.xml
+++ b/data-processing/tests/mathml-fragments/double_bar.xml
@@ -1,0 +1,4 @@
+<mrow>
+    <mi mathvariant="normal" s2:start="0" s2:end="1" s2:index="0">∣</mi>
+    <mi mathvariant="normal" s2:start="1" s2:end="2" s2:index="1">∣</mi>
+</mrow>

--- a/data-processing/tests/mathml-fragments/script_x_regular_y.xml
+++ b/data-processing/tests/mathml-fragments/script_x_regular_y.xml
@@ -1,0 +1,4 @@
+<mrow>
+    <mi mathvariant="script" s2:start="0" s2:end="11" s2:index="1">X</mi>
+    <mi s2:start="11" s2:end="12" s2:index="2">Y</mi>
+</mrow>

--- a/data-processing/tests/mathml-fragments/word_sub_i.xml
+++ b/data-processing/tests/mathml-fragments/word_sub_i.xml
@@ -1,0 +1,9 @@
+<mrow>
+    <mi s2:start="0" s2:end="1" s2:index="0">w</mi>
+    <mi s2:start="1" s2:end="2" s2:index="1">o</mi>
+    <mi s2:start="2" s2:end="3" s2:index="2">r</mi>
+    <msub s2:start="3" s2:end="6" s2:index="5">
+        <mi s2:start="3" s2:end="4" s2:index="3">d</mi>
+        <mi s2:start="5" s2:end="6" s2:index="4">i</mi>
+    </msub>
+</mrow>

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -49,7 +49,7 @@ def test_merge_contiguous_styled_identifiers():
     assert str(result.element) == '<mi mathvariant="bold">ReLU</mi>'
     symbol = result.symbols[0]
     assert symbol.start == 0
-    assert symbol.end == 14
+    assert symbol.end == 13
 
 
 def test_keep_identifiers_with_different_styles_separate():
@@ -61,12 +61,14 @@ def test_keep_identifiers_with_different_styles_separate():
 
 def test_merge_contiguous_identifiers_into_one_with_script():
     result = parse_element(load_fragment_tag("word_sub_i.xml"))
-    assert False
+    assert len(result.symbols) == 3
+    assert str(result.element) == "<msub><mi>word</mi><mi>i</mi></msub>"
 
 
 def test_merge_contiguous_operators():
     result = parse_element(load_fragment_tag("double_bar.xml"))
-    assert False
+    assert len(result.symbols) == 1
+    assert str(result.element) == "<mo>∣∣</mo>"
 
 
 def test_merge_contigous_symbols_delimit_at_operator():

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -61,8 +61,8 @@ def test_keep_identifiers_with_different_styles_separate():
 
 def test_merge_contiguous_identifiers_into_one_with_script():
     result = parse_element(load_fragment_tag("word_sub_i.xml"))
-    assert len(result.symbols) == 3
-    assert str(result.element) == "<msub><mi>word</mi><mi>i</mi></msub>"
+    symbol = result.symbols[0]
+    assert str(symbol.element) == "<msub><mi>word</mi><mi>i</mi></msub>"
 
 
 def test_merge_contiguous_operators():

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -33,7 +33,7 @@ def test_parse_single_symbol():
     assert result.tokens == [Token("x", "atom", 0, 1)]
 
 
-def test_merge_contiguous_symbols():
+def test_merge_contiguous_identifiers():
     result = parse_element(load_fragment_tag("relu.xml"))
     assert str(result.element) == "<mi>ReLU</mi>"
     symbol = result.symbols[0]
@@ -42,6 +42,31 @@ def test_merge_contiguous_symbols():
     assert symbol.tokens == [
         Token("ReLU", "atom", 0, 4),
     ]
+
+
+def test_merge_contiguous_styled_identifiers():
+    result = parse_element(load_fragment_tag("bold_relu.xml"))
+    assert str(result.element) == '<mi mathvariant="bold">ReLU</mi>'
+    symbol = result.symbols[0]
+    assert symbol.start == 0
+    assert symbol.end == 14
+
+
+def test_keep_identifiers_with_different_styles_separate():
+    result = parse_element(load_fragment_tag("script_x_regular_y.xml"))
+    assert len(result.symbols) == 2
+    assert str(result.symbols[0].element) == '<mi mathvariant="script">X</mi>'
+    assert str(result.symbols[1].element) == "<mi>Y</mi>"
+
+
+def test_merge_contiguous_identifiers_into_one_with_script():
+    result = parse_element(load_fragment_tag("word_sub_i.xml"))
+    assert False
+
+
+def test_merge_contiguous_operators():
+    result = parse_element(load_fragment_tag("double_bar.xml"))
+    assert False
 
 
 def test_merge_contigous_symbols_delimit_at_operator():


### PR DESCRIPTION
See TODOs 2 and 11 in issue #192 on symbol segmentation.

The main issue this PR seeks to solve is one of precision extraction of complex symbols from MathML.

LaTeX symbols are detected by:
1. Extracting equations
2. Parsing those equations into MathML using KaTeX
3. Cleaning up the MathML equations
4. Visiting the elements in the MathML to find elements corresponding to symbols

The problem is that the KaTeX is sometimes a little messy. For instance the word `ReLU` is parsed into four symbols (`<mi>R</mi><mi>e</mi><mi>L</mi><mi>U</mi>`). This means that if we want ReLU to be detected as a single symbol, we need to merge together consecutive nodes into longer words.

That much has already been done. But the behavior missed a couple of corner cases. This PR addresses those corner cases. What it specifically supports is:

1. Merging the bases for script elements (e.g., turning the parse tree for `word_i`---`<mi>w</mi><mi>o</mi><mi>r</mi><msub><mi>d</mi><mi>i</mi><msub>` (where 'd' is the base)---into the simpler `<msub><mi>word</mi><mi>i</mi></msub>` (where 'word' is the base))
2. When all the characters in a row are part of a single formatted word (e.g., from the macro `\mathcal{word}`, making sure that the merged node `<mi mathvariant='script'>word</mi>` is given the style attribute `mathvariant`, and its character offsets include the macro (and not just 'word').