### PR TITLE
Pipeline: Convenience script for fetching and unpacking sources for single arXiv ID

### DIFF
--- a/data-processing/.gitignore
+++ b/data-processing/.gitignore
@@ -22,6 +22,9 @@ arxiv_ids.txt
 # Pipeline inputs and outputs
 data
 
+# Script outputs
+tmp
+
 # Pipeline logs
 logs
 

--- a/data-processing/common/fetch_arxiv.py
+++ b/data-processing/common/fetch_arxiv.py
@@ -5,30 +5,33 @@ import re
 import shutil
 import subprocess
 from tempfile import TemporaryDirectory
-from typing import List
+from typing import List, Optional
 
 import requests
 
 from common import directories
 from common.models import Metadata
-from common.types import ArxivId
+from common.types import ArxivId, Path
 
 USER_AGENT = "Andrew Head, for academic research on dissemination of scientific insight <head.andrewm@gmail.com>"
 
 
-def save_source_archive(arxiv_id: ArxivId, content: bytes) -> None:
-    archive_path = directories.arxiv_subdir("sources-archives", arxiv_id)
-    if not os.path.exists(os.path.dirname(archive_path)):
-        os.makedirs(os.path.dirname(archive_path))
-    with open(archive_path, "wb") as archive:
+def save_source_archive(
+    arxiv_id: ArxivId, content: bytes, dest: Optional[Path] = None
+) -> None:
+    if not dest:
+        dest = directories.arxiv_subdir("sources-archives", arxiv_id)
+    if not os.path.exists(os.path.dirname(dest)):
+        os.makedirs(os.path.dirname(dest))
+    with open(dest, "wb") as archive:
         archive.write(content)
 
 
-def fetch_from_arxiv(arxiv_id: ArxivId) -> None:
+def fetch_from_arxiv(arxiv_id: ArxivId, dest: Optional[Path] = None) -> None:
     logging.debug("Fetching sources for arXiv paper %s from arXiv.", arxiv_id)
     uri = "https://arxiv.org/e-print/%s" % (arxiv_id,)
     response = requests.get(uri, headers={"User-Agent": USER_AGENT})
-    save_source_archive(arxiv_id, response.content)
+    save_source_archive(arxiv_id, response.content, dest)
 
 
 def fetch_from_s3(arxiv_id: ArxivId, bucket: str) -> None:

--- a/data-processing/common/unpack.py
+++ b/data-processing/common/unpack.py
@@ -9,7 +9,7 @@ from common import directories
 from common.file_utils import clean_directory
 
 
-def _unpack(archive_path: str, dest_dir: str) -> None:
+def unpack_archive(archive_path: str, dest_dir: str) -> None:
     """
     For permissible arXiv source formats, see the 'Other formats' page for an arXiv paper.
     At the time of writing, the sources could be any of the following:
@@ -58,7 +58,7 @@ def unpack(arxiv_id: str, unpack_path: str) -> Optional[str]:
             "Directory already found at %s. Deleting contents.", unpack_path
         )
         clean_directory(unpack_path)
-    _unpack(archive_path, unpack_path)
+    unpack_archive(archive_path, unpack_path)
     return unpack_path
 
 

--- a/data-processing/scripts/fetch_arxiv_sources.py
+++ b/data-processing/scripts/fetch_arxiv_sources.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+
+from common import directories
+from common.fetch_arxiv import fetch_from_arxiv
+from common.unpack import unpack, unpack_archive
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        "Fetch and unpack sources for a single arXiv paper."
+    )
+    parser.add_argument(
+        "arxiv_id",
+        help="The arXiv ID for a paper. May include version number (i.e., 'v1', 'v2', etc.)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Directory into which the arXiv sources will be fetched.",
+        default="tmp",
+    )
+
+    args = parser.parse_args()
+    arxiv_id = args.arxiv_id
+
+    output_dir = args.output_dir
+    archives_dir = os.path.join(output_dir, "archives")
+    archive_path = os.path.join(archives_dir, directories.escape_slashes(arxiv_id))
+    sources_dir = os.path.join(output_dir, directories.escape_slashes(arxiv_id))
+
+    if not os.path.exists(archives_dir):
+        print(f"Creating directory to hold source archives at {archives_dir}.")
+        os.makedirs(archives_dir)
+
+    print(
+        f"Downloading archive of source files from arXiv for paper {arxiv_id}...",
+        end="",
+    )
+    fetch_from_arxiv(arxiv_id, dest=archive_path)
+    print("done.")
+
+    if not os.path.exists(sources_dir):
+        print(f"Creating directory to hold unpacked sources at {sources_dir}.")
+        os.makedirs(sources_dir)
+
+    print(f"Unpacking sources for paper {arxiv_id} into {sources_dir}.")
+    unpack_archive(archive_path, sources_dir)

--- a/data-processing/scripts/fetch_arxiv_sources.py
+++ b/data-processing/scripts/fetch_arxiv_sources.py
@@ -15,7 +15,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--output-dir",
-        help="Directory into which the arXiv sources will be fetched.",
+        help=(
+            "Directory into which the arXiv sources will be fetched. The fetched sources will "
+            + "be saved in a subfolder of the output folder with its name as the arXiv ID "
+            + "(i.e., 'output_dir/<arxiv_id>/')."
+        ),
         default="tmp",
     )
 


### PR DESCRIPTION
I frequently want to download and unpack the TeX sources for a single arXiv paper quickly when I am debugging issues of missing entities. The current workflow to do so requires calling a subset of the pipeline via `python scripts/run_pipeline.py --arxiv-ids <ARXIV_ID> --commands fetch-arxiv-ids` and then looking at the unpacked sources in `data/**-sources/<ARXIV_ID>`.

This was feeling a bit cumbersome, so I wrote a convenience script for fetching just a single project and unpacking it to `./tmp/<ARXIV_ID>`. The new invocation is:

```bash
python scripts/fetch_arxiv_sources.py <ARXIV_ID>
```

I am submitting for review as I would be happy to merge it to main if it was thought that this would be of general interest. That said, this might be an optimization for just one person (me) ^_^ Would love to hear your thoughts---does this belong in the ScholarPhi repo?