### PR TITLE
Use bearer token check to restrict write-apis

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -63,7 +63,8 @@ is one. Once you have the values, put them in a file called
   },
   "s2": {
     "apiKey": "<key>"
-  }
+  },
+  "adminToken": "<randomly-generated-token-for-write-access-to-apis>"
 }
 ```
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1496,23 +1496,28 @@
         "@types/node": "*"
       }
     },
+    "@types/hapi-auth-bearer-token": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi-auth-bearer-token/-/hapi-auth-bearer-token-6.1.2.tgz",
+      "integrity": "sha512-zwR3VBoVVHOZ/+lFe5QSgJkT/thJU+sjBFijMQGMkp4vk9ZD21/01AXyWwKw6h6YNBvPzGAlm/WvNhBDZxRqMw==",
+      "requires": {
+        "@types/hapi__hapi": "*"
+      }
+    },
     "@types/hapi__boom": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@types/hapi__boom/-/hapi__boom-7.4.1.tgz",
-      "integrity": "sha512-x/ZK824GomII7Yoei/nMoB46NQcSfGe0iVpZK3uUivxIAfUUSzRvu8RQO7ZkKapIgzgshHZc+GR+z/BQ8l2VLg==",
-      "dev": true
+      "integrity": "sha512-x/ZK824GomII7Yoei/nMoB46NQcSfGe0iVpZK3uUivxIAfUUSzRvu8RQO7ZkKapIgzgshHZc+GR+z/BQ8l2VLg=="
     },
     "@types/hapi__catbox": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.2.tgz",
-      "integrity": "sha512-AWK70LgRsRWL1TNw+aT0IlS56E0pobvFdr/en0K8XazyK4Ey6T/jXhQqv/iQ6FJAAU+somMzgmt9fWq2TaaOkA==",
-      "dev": true
+      "integrity": "sha512-AWK70LgRsRWL1TNw+aT0IlS56E0pobvFdr/en0K8XazyK4Ey6T/jXhQqv/iQ6FJAAU+somMzgmt9fWq2TaaOkA=="
     },
     "@types/hapi__hapi": {
       "version": "18.2.5",
       "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-18.2.5.tgz",
       "integrity": "sha512-hCAQVtE3OZCihJrn5SxQYmAkIdtE1BwAyvGkxwnPwP+IIe0MQxqbP2s0cwlAwimGOdDQ/ArH+7i6FGDKPlZhFQ==",
-      "dev": true,
       "requires": {
         "@types/hapi__boom": "*",
         "@types/hapi__catbox": "*",
@@ -1528,7 +1533,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__iron/-/hapi__iron-5.1.0.tgz",
       "integrity": "sha512-RxYHIc8wFe8M1jMwgovskoHNVjuP1q0tUGCNnbHnhA4SBMyYg+JHIAz8yFibSwgF4gWYh5yHMpbmK5kmnG4HRA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1536,14 +1540,12 @@
     "@types/hapi__joi": {
       "version": "16.0.2",
       "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-16.0.2.tgz",
-      "integrity": "sha512-mBJ70SvfnlmeVNRiq34M0FwZ0xkFwwLN2eQkneT2DStDITKiWEV4ycE2Muq0PavBj+pc8wVtxpJwAR+YAMIplg==",
-      "dev": true
+      "integrity": "sha512-mBJ70SvfnlmeVNRiq34M0FwZ0xkFwwLN2eQkneT2DStDITKiWEV4ycE2Muq0PavBj+pc8wVtxpJwAR+YAMIplg=="
     },
     "@types/hapi__mimos": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.0.tgz",
       "integrity": "sha512-hcdSoYa32wcP+sEfyf85ieGwElwokcZ/mma8eyqQ4OTHeCAGwfaoiGxjG4z1Dm+RGhIYLHlW54ji5FFwahH12A==",
-      "dev": true,
       "requires": {
         "@types/mime-db": "*"
       }
@@ -1551,14 +1553,12 @@
     "@types/hapi__podium": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__podium/-/hapi__podium-3.4.0.tgz",
-      "integrity": "sha512-LE85jLgqR5HscGQ7SaSz6FMRsKlQ1wHVbYc9u0yq7NKDRvZiQFIrr3Pl1RPzK7QNUdZP8zmJibe8q0JcafTAJQ==",
-      "dev": true
+      "integrity": "sha512-LE85jLgqR5HscGQ7SaSz6FMRsKlQ1wHVbYc9u0yq7NKDRvZiQFIrr3Pl1RPzK7QNUdZP8zmJibe8q0JcafTAJQ=="
     },
     "@types/hapi__shot": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.0.tgz",
       "integrity": "sha512-vIySJYkwIGXMB5eFaZu3U8dS9CAZmteJfmkRn9bYH5uNcSvVgiwDROiwAkD7ej88qA+RZPkUK70KmeDs3LRHvw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1712,8 +1712,7 @@
     "@types/mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
-      "dev": true
+      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I="
     },
     "@types/nconf": {
       "version": "0.10.0",
@@ -1724,8 +1723,7 @@
     "@types/node": {
       "version": "12.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
-      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
-      "dev": true
+      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3196,6 +3194,41 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "hapi-auth-bearer-token": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/hapi-auth-bearer-token/-/hapi-auth-bearer-token-6.2.1.tgz",
+      "integrity": "sha512-8HeeT3vvbE2TUBxoX+XdwTwjvdBKEJz+UOdcJ8xf182p2gBCrjdUXZboFbf0Ef3QrPtMQ4lTYRO5F8sL6jnWWQ==",
+      "requires": {
+        "@hapi/boom": "^7.4.2",
+        "@hapi/hoek": "^6.2.3",
+        "@hapi/joi": "^15.0.3"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+        },
+        "@hapi/joi": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+          "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+          "requires": {
+            "@hapi/address": "2.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/hoek": "8.x.x",
+            "@hapi/topo": "3.x.x"
+          },
+          "dependencies": {
+            "@hapi/hoek": {
+              "version": "8.5.1",
+              "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+              "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+            }
+          }
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/hapi__hapi": "^18.2.5",
     "@types/hapi__joi": "^16.0.2",
+    "@types/hapi-auth-bearer-token": "^6.1.2",
     "@types/jest": "^26.0.3",
     "@types/nconf": "^0.10.0",
     "@types/pg": "^7.14.7",
@@ -38,6 +39,7 @@
     "@hapi/joi": "^16.1.7",
     "@types/lru-cache": "^5.1.0",
     "axios": "^0.21.1",
+    "hapi-auth-bearer-token": "^6.2.1",
     "knex": "^0.21.13",
     "lru-cache": "^6.0.0",
     "nconf": "^0.11.0",

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -44,12 +44,16 @@ export const plugin = {
     server.auth.strategy('admin-token', 'bearer-access-token', {
       allowQueryToken: true,
       validate: async (request, token, h) => {
-          const isValid = token === config.adminToken;
+        const credentials = { token };
+        const artifacts = { };
 
-          const credentials = { token };
-          const artifacts = { };
+        // if no token has been set, fail all requests
+        if(!token) {
+          return { isValid: false, credentials, artifacts};
+        }
 
-          return { isValid, credentials, artifacts };
+        const isValid = token === config.adminToken;
+        return { isValid, credentials, artifacts };
       }
   });
 

--- a/api/src/conf.ts
+++ b/api/src/conf.ts
@@ -33,7 +33,8 @@ export class Config {
     constructor(
         readonly db: DBConfig,
         readonly s2: S2APIConfig,
-        readonly adminToken: string
+        // auth for write apis, those apis will be disabled unless a value is specified
+        readonly adminToken: string 
     ) {}
 
     static fromConfig(conf: nconf.Provider) {

--- a/api/src/conf.ts
+++ b/api/src/conf.ts
@@ -32,15 +32,18 @@ export class S2APIConfig {
 export class Config {
     constructor(
         readonly db: DBConfig,
-        readonly s2: S2APIConfig
+        readonly s2: S2APIConfig,
+        readonly adminToken: string
     ) {}
 
     static fromConfig(conf: nconf.Provider) {
         const db = conf.get("database");
         const s2 = conf.get("s2"); 
+        const adminToken = conf.get("adminToken");
         return new Config(
             new DBConfig(db.host, db.database, db.user, db.password, db.port, db.schema),
-            new S2APIConfig(s2 && s2.apiKey)
+            new S2APIConfig(s2 && s2.apiKey),
+            adminToken
         );
     }
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ nconf
       port: 5432,
       schema: "public",
     },
+    adminToken: "local"
   });
 
 process.on("unhandledRejection", (err) => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,7 +11,6 @@ nconf
       port: 5432,
       schema: "public",
     },
-    adminToken: "local"
   });
 
 process.on("unhandledRejection", (err) => {

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -642,7 +642,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=test",
         payload,
       });
 
@@ -710,7 +710,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=test",
         payload,
       });
 
@@ -794,7 +794,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=test",
         payload,
       });
 
@@ -953,7 +953,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "delete",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=test",
       });
 
       expect(response.statusCode).toEqual(204);

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -963,6 +963,36 @@ describe("API", () => {
       expect(await knex("boundingbox").select()).toHaveLength(0);
       expect(await knex("entitydata").select()).toHaveLength(0);
     });
+
+    test("request with no access token fails", async () => {
+      await knex("paper").insert({
+        s2_id: "s2id",
+        arxiv_id: "1111.1111",
+      } as PaperRow);
+      await knex("version").insert({
+        id: 1,
+        paper_id: "s2id",
+        index: 0,
+      } as VersionRow);
+      await knex.batchInsert("entity", [
+        {
+          id: 1,
+          paper_id: "s2id",
+          version: 0,
+          type: "unknown",
+          source: "test",
+        },
+      ] as EntityRow[]);
+
+      const response = await server.inject({
+        method: "delete",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1",
+      });
+
+      expect(response.statusCode).toEqual(401);
+
+      expect(await knex("entity").select()).toHaveLength(1);
+    });
   });
 
   describe("GET /api/v0/papers/arxiv:{arxivId}/version", () => {

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -877,7 +877,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=test",
         payload,
       });
 

--- a/api/src/tests/api.test.ts
+++ b/api/src/tests/api.test.ts
@@ -642,7 +642,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
         payload,
       });
 
@@ -710,7 +710,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
         payload,
       });
 
@@ -794,7 +794,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "patch",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
         payload,
       });
 
@@ -953,7 +953,7 @@ describe("API", () => {
 
       const response = await server.inject({
         method: "delete",
-        url: "/api/v0/papers/arxiv:1111.1111/entities/1",
+        url: "/api/v0/papers/arxiv:1111.1111/entities/1?access_token=local",
       });
 
       expect(response.statusCode).toEqual(204);

--- a/api/src/tests/setup.ts
+++ b/api/src/tests/setup.ts
@@ -22,6 +22,7 @@ nconf
       password: "pdfsarefun",
       schema: "test"
     },
+    adminToken: "test"
   });
 
 const config = conf.Config.fromConfig(nconf);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1634,6 +1634,12 @@
       "integrity": "sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==",
       "dev": true
     },
+    "@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "dev": true
+    },
     "@types/dompurify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.0.0.tgz",
@@ -4532,10 +4538,9 @@
       }
     },
     "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "dev": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -6451,6 +6456,12 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
           "dev": true
         },
         "debug": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "@material-ui/icons": "^4.5.1",
     "axios": "^0.21.0",
     "classnames": "^2.2.6",
+    "cookie": "^0.4.1",
     "dompurify": "^2.0.7",
     "katex": "^0.12.0",
     "labella": "^1.1.4",
@@ -92,6 +93,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",
+    "@types/cookie": "^0.4.0",
     "@types/dompurify": "^2.0.0",
     "@types/node": "^12.12.9",
     "@types/pdfjs-dist": "^2.1.2",

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosResponse } from "axios";
+import cookie from "cookie";
 import { addLibraryEntryUrl, userInfoUrl } from "./s2-url";
 import { UserInfo, UserLibrary } from "../state";
 import {
@@ -11,6 +12,12 @@ import {
   Paginated,
   PaperIdWithEntityCounts,
 } from "./types";
+
+const token = cookie.parse(document.cookie)["readerAdminToken"];
+
+const config = {
+  headers: { Authorization: `Bearer ${token}` }
+};
 
 export async function listPapers(offset: number = 0, size: number = 25) {
   return axios.get<Paginated<PaperIdWithEntityCounts>>(
@@ -85,7 +92,8 @@ export async function patchEntity(
 ): Promise<boolean> {
   const response = await axios.patch(
     `/api/v0/papers/arxiv:${arxivId}/entities/${data.id}`,
-    { data } as EntityUpdatePayload
+    { data } as EntityUpdatePayload,
+    config
   );
   if (response.status === 204) {
     return true;
@@ -102,7 +110,8 @@ export async function deleteEntity(
   id: string
 ): Promise<boolean> {
   const response = await axios.delete(
-    `/api/v0/papers/arxiv:${arxivId}/entities/${id}`
+    `/api/v0/papers/arxiv:${arxivId}/entities/${id}`,
+    config
   );
   if (response.status === 204) {
     return true;


### PR DESCRIPTION
Fixes https://github.com/allenai/scholar/issues/25340

After this change, calls to the 2 apis that allow directly modifying data in the db will require an access token be set in the request. I've updated the UI app so it will try to read the token from a cookie named `readerAdminToken` that people can set locally. We can share the token value in slack or something.

If directly hitting the api, the token can be set in the query string like:
`?access_token={token}`

Or via headers like:
`Authorization: Bearer {token}`

The token checking is handled by an off the shelf hapi plugin I've added to the stack called `hapi-auth-bearer-token`.

The token is stored in the skiff secrets store and can be updated there at will. When running locally a static token value of `"local"` is used.

## Longer term

Longer term we could create users with passwords in the db or piggy back on google oauth or something but that's a little trickier to do in a way that this open source projects remains accessible for others to run locally.