### PR TITLE
Restore native link functionality

### DIFF
--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -29,9 +29,8 @@
  * border styles. See the pdf.js code setting border styles here:
  * https://github.com/mozilla/pdf.js/blob/474fe1757e654e67d20a53774edb293aa073ce0b/src/display/annotation_layer.js#L19
  */
-.annotationLayer .linkAnnotation {
+.annotationLayer .linkAnnotation > a {
   border: none !important;
-  display: none !important;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/allenai/scholar/issues/26381

This puts the native link functionality back in to the reader so things like links to other pages or internal links to headers work again.

@andrewhead I wanted to understand if there were overlapping issues you ran into before where these link annotations and our own would fight, do we need to bump these down in the z-order or something for that case or do you think this'll be okay?

Before:
Example from the [PAWLS paper](https://scholarphi.semanticscholar.org/?file=https://arxiv.org/pdf/2101.10281v1.pdf) where this links to the app aren't clickable today:
![image](https://user-images.githubusercontent.com/399279/108134199-9e52c180-706a-11eb-81b5-cd9cf20beb10.png)

After: 
They are clickable and have a highlight hover:
![image](https://user-images.githubusercontent.com/399279/108134253-bde9ea00-706a-11eb-858f-860eddae4b1c.png)


