### PR TITLE
Log entity load time in heap

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -732,6 +732,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
         this.setState({
           areCitationsLoading: true
         });
+        const loadingStartTime = performance.now();
         const entities = await api.getEntities(this.props.paperId.id);
         this.setState({
           entities: stateUtils.createRelationalStoreFromArray(entities, "id"),
@@ -751,6 +752,11 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             {} as { [s2Id: string]: Paper }
           );
           this.setState({ papers, areCitationsLoading: false });
+        }
+
+        if (window.heap) {
+          const loadingTimeMS = Math.round(performance.now() - loadingStartTime);
+          window.heap.track("paper-loaded", { loadingTimeMS });
         }
 
         const userData = await api.getUserLibraryInfo();

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -756,7 +756,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
 
         if (window.heap) {
           const loadingTimeMS = Math.round(performance.now() - loadingStartTime);
-          window.heap.track("paper-loaded", { loadingTimeMS });
+          window.heap.track("paper-loaded", { loadingTimeMS, numEntities: entities.length, numCitations: citationS2Ids.length });
         }
 
         const userData = await api.getUserLibraryInfo();


### PR DESCRIPTION
Fixes https://github.com/allenai/scholar/issues/26776

This PR logs the amount of time it takes to fetch all the entities/citations to heap. This will give us a helpful view on this as we make improvements.

Example request browser is making to heap with this data in it:
![image](https://user-images.githubusercontent.com/399279/108137552-ed9bf080-7070-11eb-8b3a-5032286ec5ab.png)
