### PR TITLE
Allow unexpected errors to bubble up.

### DIFF
--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-import traceback
 import uuid
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
@@ -75,10 +74,10 @@ def run_commands_for_arxiv_ids(
         # Catch-all for unexpected errors from running commands. With the amount of networking
         # and subprocess calls in the commands, it is simply unlikely that we can predict and
         # write exceptions for every possible exception that could be thrown.
-        except Exception:  # pylint: disable=broad-except
-            logging.error(
-                "Unexpected exception processing paper: %s", traceback.format_exc()
-            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error("Unexpected exception processing papers: {}".format(arxiv_id_list), exc)
+            raise exc
+
         logging.info("Finished running command %s", CommandCls.get_name())
 
     # Create digest describing the result of running these commands for these papers


### PR DESCRIPTION
This maintains a consistent "interface" for any
calling application -- non-0 exit code represents
a failure outcome for the requested paper(s).