### PR TITLE
Consolidate routes that accept both types of IDs

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -192,18 +192,18 @@ export const plugin = {
 
     server.route({
       method: "POST",
-      path: "papers/arxiv:{arxivId}/entities",
+      path: "papers/{arxivSelector}/entities",
       handler: async (request, h) => {
-        const arxivId = request.params.arxivId;
+        const paperSelector = parsePaperSelector(request.params.arxivSelector);
         const entity = await dbConnection.createEntity(
-          { arxiv_id: arxivId },
+          paperSelector,
           (request.payload as EntityCreatePayload).data
         );
         return h.response({ data: entity }).code(201);
       },
       options: {
         validate: {
-          params: validation.arxivId,
+          params: validation.arxivOnlySelector,
           payload: validation.entityPost,
         },
       },
@@ -211,7 +211,7 @@ export const plugin = {
 
     server.route({
       method: "PATCH",
-      path: "papers/arxiv:{arxivId}/entities/{id}",
+      path: "papers/{arxivSelector}/entities/{id}",
       handler: async (request, h) => {
         await dbConnection.updateEntity(
           (request.payload as EntityUpdatePayload).data
@@ -221,7 +221,7 @@ export const plugin = {
       options: {
         auth: 'admin-token',
         validate: {
-          params: validation.arxivId.append({
+          params: validation.arxivOnlySelector.append({
             id: Joi.string().required(),
           }),
           payload: validation.entityPatch,
@@ -231,7 +231,7 @@ export const plugin = {
 
     server.route({
       method: "DELETE",
-      path: "papers/arxiv:{arxivId}/entities/{id}",
+      path: "papers/{arxivSelector}/entities/{id}",
       handler: async (request, h) => {
         const { id } = request.params;
         await dbConnection.deleteEntity(id);
@@ -240,7 +240,7 @@ export const plugin = {
       options: {
         auth: 'admin-token',
         validate: {
-          params: validation.arxivId.append({
+          params: validation.arxivOnlySelector.append({
             id: Joi.string().required(),
           }),
         },
@@ -249,9 +249,9 @@ export const plugin = {
 
     server.route({
       method: "GET",
-      path: "papers/arxiv:{arxivId}/version",
+      path: "papers/{arxivSelector}/version",
       handler: async (request, h) => {
-        const paperSelector = { arxiv_id: request.params.arxivId };
+        const paperSelector = parsePaperSelector(request.params.arxivSelector);
         const version = await dbConnection.getLatestProcessedArxivVersion(paperSelector);
         const citationCount = await dbConnection.getPaperEntityCount(paperSelector, 'citation');
         if (!version || !citationCount) {
@@ -263,7 +263,7 @@ export const plugin = {
       },
       options: {
         validate: {
-          params: validation.arxivId,
+          params: validation.arxivOnlySelector,
         },
       },
     });

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -662,7 +662,7 @@ export class Connection {
 /**
  * Expected knex.js parameters for selecting a paper. Map from paper table column ID to value.
  */
-type PaperSelector = ArxivIdPaperSelector | S2IdPaperSelector;
+export type PaperSelector = ArxivIdPaperSelector | S2IdPaperSelector;
 
 interface ArxivIdPaperSelector {
   arxiv_id: string;

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -18,8 +18,22 @@ export const logEntry = Joi.object({
   data: Joi.object().unknown(true).default(null),
 });
 
-export const s2Id = Joi.object({
-  s2Id: Joi.string().pattern(/[a-f0-9]{40}/),
+const s2paperId = Joi.string().pattern(/[a-f0-9]{40}/);
+/*
+ * See the arXiv documentation on valid identifiers here:
+ * https://arxiv.org/help/arxiv_identifier.
+ */
+const currentArxivFormat = Joi.string().pattern(/arxiv:[0-9]{2}[0-9]{2}.[0-9]+(v[0-9]+)?/);
+const olderArxivFormat = Joi.string().pattern(
+  /arxiv:[a-zA-Z0-9-]+\.[A-Z]{2}\/[0-9]{2}[0-9]{2}[0-9]+(v[0-9]+)/
+);
+
+export const paperSelector = Joi.object({
+  paperSelector: Joi.alternatives().try(
+    s2paperId,
+    currentArxivFormat,
+    olderArxivFormat,
+  )
 });
 
 /**
@@ -27,21 +41,9 @@ export const s2Id = Joi.object({
  * version of Hapi needed an object to use the 'alternatives' feature.
  */
 export const arxivId = Joi.object({
-  /*
-   * See the arXiv documentation on valid identifiers here:
-   * https://arxiv.org/help/arxiv_identifier.
-   */
   arxivId: Joi.alternatives().try(
-    /*
-     * Current arXiv ID format.
-     */
-    Joi.string().pattern(/[0-9]{2}[0-9]{2}.[0-9]+(v[0-9]+)?/),
-    /*
-     * Older arXiv ID format.
-     */
-    Joi.string().pattern(
-      /[a-zA-Z0-9-]+\.[A-Z]{2}\/[0-9]{2}[0-9]{2}[0-9]+(v[0-9]+)/
-    )
+    currentArxivFormat,
+    olderArxivFormat
   ),
 });
 

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -40,8 +40,8 @@ export const paperSelector = Joi.object({
  * arXiv ID needed to be wrapped in 'Joi.object' at the time of writing this as the contemporary
  * version of Hapi needed an object to use the 'alternatives' feature.
  */
-export const arxivId = Joi.object({
-  arxivId: Joi.alternatives().try(
+export const arxivOnlySelector = Joi.object({
+  arxivSelector: Joi.alternatives().try(
     currentArxivFormat,
     olderArxivFormat
   ),


### PR DESCRIPTION
I redid the way we extract PaperSelectors out of the route params so that we no longer have to implement a route twice to handle both arxiv and S2 IDs. For routes that only work on arxiv IDs, there's an `arxivOnlySelector` validation option that rejects S2 IDs. I also noticed some of those routes validate a correctly-shaped arxiv ID but then only use the entity ID later in the route, indicating we can simplify the API routes (or do more validation on the paper).