### PR TITLE
Remove entity counts from /papers page to make it useable again

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -7,7 +7,7 @@ import {
   EntityCreatePayload,
   EntityUpdatePayload,
   Paper,
-  PaperWithEntityCounts,
+  PaperWithIdInfo,
   Paginated,
   EntityType
 } from "./types/api";
@@ -91,7 +91,7 @@ export const plugin = {
           }
           s2PaperInfoByPaperId[s2Paper.s2Id] = s2Paper;
         }
-        const mergedPapers: PaperWithEntityCounts[] = [];
+        const mergedPapers: PaperWithIdInfo[] = [];
         for (const paper of papers.rows) {
           const maybeS2Paper = s2PaperInfoByPaperId[paper.s2_id];
           mergedPapers.push({
@@ -106,7 +106,7 @@ export const plugin = {
             citationVelocity: maybeS2Paper?.citationVelocity
           });
         }
-        const response: Paginated<PaperWithEntityCounts> = { ...papers, ...{ rows: mergedPapers } };
+        const response: Paginated<PaperWithIdInfo> = { ...papers, ...{ rows: mergedPapers } };
         return response;
       },
     });

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -61,7 +61,7 @@ export class Connection {
     return await this._knex("logentry").insert(logEntry);
   }
 
-  async getAllPapers(offset: number = 0, size: number = 25, entity_type='citations'): Promise<Paginated<PaperIdInfo>> {
+  async getAllPapers(offset: number = 0, size: number = 25, entity_type: EntityType='citation'): Promise<Paginated<PaperIdInfo>> {
     type Row = PaperIdInfo & {
       total_count: string;
     }
@@ -76,17 +76,17 @@ export class Connection {
                  FROM version
              GROUP BY paper_id ) AS version
           ON version.paper_id = paper.s2_id
-   LEFT JOIN entity
+        JOIN entity
           ON entity.paper_id = paper.s2_id
          AND entity.version = version.index
-         AND entity.type = '${entity_type}'
+         AND entity.type = ?
     GROUP BY paper.s2_id,
              paper.arxiv_id,
              version.index
     ORDER BY paper.arxiv_id DESC
       OFFSET ${offset}
        LIMIT ${size}
-    `);
+    `, [entity_type]);
     const rows = response.rows.map(r => ({
         arxiv_id: r.arxiv_id,
         s2_id: r.s2_id,

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -61,7 +61,7 @@ export class Connection {
     return await this._knex("logentry").insert(logEntry);
   }
 
-  async getAllPapers(offset: number = 0, size: number = 25, entity_type: EntityType='citation'): Promise<Paginated<PaperIdInfo>> {
+  async getAllPapers(offset: number = 0, size: number = 25, entity_type: EntityType = 'citation'): Promise<Paginated<PaperIdInfo>> {
     type Row = PaperIdInfo & {
       total_count: string;
     }

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -8,7 +8,7 @@ import {
   GenericAttributes,
   GenericRelationships,
   Paginated,
-  PaperIdWithEntityCounts,
+  PaperIdInfo,
   Relationship,
 } from "./types/api";
 import * as validation from "./types/validation";
@@ -61,28 +61,14 @@ export class Connection {
     return await this._knex("logentry").insert(logEntry);
   }
 
-  async getAllPapers(offset: number = 0, size: number = 25): Promise<Paginated<PaperIdWithEntityCounts>> {
-    // We use a local type to capture the fact that counts will come across the wire
-    // as a string.
-    type Row = PaperIdWithEntityCounts & {
-        symbol_count: string;
-        citation_count: string;
-        sentence_count: string;
-        term_count: string;
-        equation_count: string;
-        entity_count: string;
-        total_count: string;
-    };
+  async getAllPapers(offset: number = 0, size: number = 25, entity_type='citations'): Promise<Paginated<PaperIdInfo>> {
+    type Row = PaperIdInfo & {
+      total_count: string;
+    }
     const response = await this._knex.raw<{ rows: Row[] }>(`
       SELECT paper.arxiv_id,
              paper.s2_id,
              version.index AS version,
-             SUM(CASE WHEN entity.type = 'symbol' THEN 1 ELSE 0 END) AS symbol_count,
-             SUM(CASE WHEN entity.type = 'citation' THEN 1 ELSE 0 END) AS citation_count,
-             SUM(CASE WHEN entity.type = 'sentence' THEN 1 ELSE 0 END) AS sentence_count,
-             SUM(CASE WHEN entity.type = 'term' THEN 1 ELSE 0 END) AS term_count,
-             SUM(CASE WHEN entity.type = 'equation' THEN 1 ELSE 0 END) AS equation_count,
-             COUNT(entity.*) AS entity_count,
              COUNT(*) OVER() as total_count
         FROM paper
         JOIN ( SELECT MAX(index) AS index,
@@ -93,6 +79,7 @@ export class Connection {
    LEFT JOIN entity
           ON entity.paper_id = paper.s2_id
          AND entity.version = version.index
+         AND entity.type = '${entity_type}'
     GROUP BY paper.s2_id,
              paper.arxiv_id,
              version.index
@@ -104,12 +91,6 @@ export class Connection {
         arxiv_id: r.arxiv_id,
         s2_id: r.s2_id,
         version: r.version,
-        symbol_count: parseInt(r.symbol_count),
-        citation_count: parseInt(r.citation_count),
-        sentence_count: parseInt(r.sentence_count),
-        term_count: parseInt(r.term_count),
-        equation_count: parseInt(r.equation_count),
-        entity_count: parseInt(r.entity_count)
     }));
     const total = parseInt(response.rows[0].total_count);
     return { rows, offset, size, total };

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -19,6 +19,12 @@ export interface Paginated<T> {
   total: number;
 }
 
+export interface PaperIdInfo {
+  s2_id: string;
+  arxiv_id?: string;
+  version: number;
+}
+
 export interface PaperIdWithEntityCounts {
   s2_id: string;
   arxiv_id?: string;
@@ -48,6 +54,17 @@ export interface Paper {
 }
 
 export interface PaperWithEntityCounts extends PaperIdWithEntityCounts {
+  abstract?: string;
+  authors?: Author[];
+  title?: string;
+  url?: string;
+  venue?: string;
+  year?: number | null;
+  influentialCitationCount?: number;
+  citationVelocity?: number;
+}
+
+export interface PaperWithIdInfo extends PaperIdInfo {
   abstract?: string;
   authors?: Author[];
   title?: string;

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -58,6 +58,23 @@ export interface PaperWithEntityCounts extends PaperIdWithEntityCounts {
   citationVelocity?: number;
 }
 
+export interface PaperIdInfo {
+  s2_id: string;
+  arxiv_id?: string;
+  version: number;
+}
+
+export interface PaperWithIdInfo extends PaperIdInfo {
+  abstract?: string;
+  authors?: Author[];
+  title?: string;
+  url?: string;
+  venue?: string;
+  year?: number | null;
+  influentialCitationCount?: number;
+  citationVelocity?: number;
+}
+
 export interface Author {
   id: string;
   name: string;

--- a/ui/src/papers/index.tsx
+++ b/ui/src/papers/index.tsx
@@ -8,7 +8,7 @@
  * the general reader interface slightly.
  */
 import { listPapers } from "../api/api";
-import { Paginated, PaperWithEntityCounts } from "../api/types";
+import { Paginated, PaperWithIdInfo } from "../api/types";
 
 import AppBar from "@material-ui/core/AppBar";
 import Box from "@material-ui/core/Box";
@@ -90,7 +90,7 @@ const PaperList = () => {
     getOffsetFromURL(0),
     getSizeFromURL(25)
   ));
-  const [ results, setResults ] = useState<Paginated<PaperWithEntityCounts>>();
+  const [ results, setResults ] = useState<Paginated<PaperWithIdInfo>>();
   const [ state, setState ] = useState<ViewState>(ViewState.Loading);
 
   useEffect(() => {
@@ -135,12 +135,6 @@ const PaperList = () => {
                 <TableCell>Paper</TableCell>
                 <TableCell>Reader Link</TableCell>
                 <TableCell>ArXiv ID</TableCell>
-                <TableCell>Symbols</TableCell>
-                <TableCell>Citations</TableCell>
-                <TableCell>Equations</TableCell>
-                <TableCell>Terms</TableCell>
-                <TableCell>Sentences</TableCell>
-                <TableCell>Total Entities</TableCell>
                 <TableCell>Entity Version</TableCell>
               </TableRow>
             </TableHead>
@@ -185,12 +179,6 @@ const PaperList = () => {
                         </a>
                       ) : null}
                     </TableCell>
-                    <TableCell>{paper.symbol_count}</TableCell>
-                    <TableCell>{paper.citation_count}</TableCell>
-                    <TableCell>{paper.equation_count}</TableCell>
-                    <TableCell>{paper.term_count}</TableCell>
-                    <TableCell>{paper.sentence_count}</TableCell>
-                    <TableCell>{paper.entity_count}</TableCell>
                     <TableCell>{paper.version}</TableCell>
                   </TableRow>
                 );


### PR DESCRIPTION
Fixes https://github.com/allenai/scholar/issues/26610

As the DB size has grown, the query here to fetch all papers and their counts have started to timeout our ELB at 60s (which is also way too long to wait anyway).

Since we don't value the counts enough to improve the performance of this query in this PR I propose that we drop the counts altogether. The page now loads instantly with a list of papers that have any citation entities (which is our current bar for displaying a link on the PDP as well).

Before:
![image](https://user-images.githubusercontent.com/399279/108889248-02bcd600-75c1-11eb-9d62-63ff29134d21.png)


After:
![image](https://user-images.githubusercontent.com/399279/108889214-fa649b00-75c0-11eb-96d8-f6e1957e391c.png)
