### PR TITLE
Speed up version check query

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -254,12 +254,14 @@ export const plugin = {
         const paperSelector = parsePaperSelector(request.params.arxivSelector);
         const version = await dbConnection.getLatestProcessedArxivVersion(paperSelector);
         const citationCount = version !== null ? await dbConnection.getPaperEntityCount(paperSelector, 'citation'): null;
-        if (version === null || citationCount === null) {
+
+        if(citationCount && citationCount > 0) {
+          return h.response({ version }).code(200);
+        } else {
           // We don't have version info for this ID, or no citations were extracted so we consider
           // it unsuccessfully processed.
           return h.response().code(404);
-        }
-        return h.response({ version }).code(200);
+        }    
       },
       options: {
         validate: {

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -253,8 +253,8 @@ export const plugin = {
       handler: async (request, h) => {
         const paperSelector = parsePaperSelector(request.params.arxivSelector);
         const version = await dbConnection.getLatestProcessedArxivVersion(paperSelector);
-        const citationCount = await dbConnection.getPaperEntityCount(paperSelector, 'citation');
-        if (!version || !citationCount) {
+        const citationCount = version !== null ? await dbConnection.getPaperEntityCount(paperSelector, 'citation'): null;
+        if (version === null || citationCount === null) {
           // We don't have version info for this ID, or no citations were extracted so we consider
           // it unsuccessfully processed.
           return h.response().code(404);

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -101,18 +101,22 @@ export class Connection {
     const idValue = isS2Selector(paperSelector) ? paperSelector.s2_id : `${paperSelector.arxiv_id}%`;
     const whereClause = `${idField} ${isS2Selector(paperSelector) ? '=' : 'ilike'} ?`
     const response = await this._knex.raw<{ rows: {count: number, id: string}[] }>(`
-      select count(e.*), ${idField}
-      from paper p
-      join entity e on e.paper_id = p.s2_id
-      join (
-        select paper_id, max(version) as max_version
-        from entity
-        group by paper_id
-      ) as maximum on maximum.paper_id = e.paper_id
-      where e.version = maximum.max_version
-      and ${whereClause}
-      and e.type = ?
-      group by p.s2_id
+      SELECT count(e.*), ${idField}
+      FROM paper p
+      JOIN entity e on e.paper_id = p.s2_id
+      JOIN (
+        SELECT 
+          paper_id, 
+          MAX(index) AS max_version 
+        FROM 
+          version 
+        GROUP BY 
+          paper_id
+      ) AS maximum ON maximum.paper_id = e.paper_id     
+      WHERE e.version = maximum.max_version
+      AND ${whereClause}
+      AND e.type = ?
+      GROUP BY p.s2_id
     `, [idValue, entityType]);
     if (response.rows.length > 0) {
       return response.rows[0].count;


### PR DESCRIPTION
Fixes https://github.com/allenai/scholar/issues/26728

Today this call takes ~3-4s to complete, leading to a delay in when a user might see the reader link appear and might have scrolled down the page and missed it. After this PR it takes ~300ms.

When I'd first added this citation count check I had mostly copied and pasted how the max version was being found in the /papers query which turns out to have been horrifically slow. We can instead grab the latest version directly from the `version` table which is tiny compared to the entity table.