### PR TITLE
S2 api handling

### DIFF
--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -20,7 +20,7 @@ from common.commands.fetch_arxiv_sources import (
     FetchArxivSources,
 )
 from common.commands.fetch_new_arxiv_ids import FetchNewArxivIds
-from common.commands.fetch_s2_data import S2MetadataException
+from common.commands.fetch_s2_data import S2ApiException
 from common.commands.locate_entities import LocateEntitiesCommand
 from common.commands.store_pipeline_log import StorePipelineLog
 from common.commands.store_results import DEFAULT_S3_LOGS_BUCKET, StoreResults
@@ -474,7 +474,7 @@ if __name__ == "__main__":
                 # The pipeline digest must be updated after each arXiv ID is processed, because the
                 # digest for a paper cannot be computed once the paper's data is deleted.
                 pipeline_digest.update(digest_for_paper)
-            except S2MetadataException as e:
+            except S2ApiException as e:
                 logging.error("Retryable Failure processing id: {arxiv_id}", e)
                 exit(RETRYABLE_FAILURE_RETURN_CODE)
             finally:

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -1,18 +1,87 @@
 from typing import List
 from dataclasses import dataclass
+from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
-from common.commands.fetch_s2_data import FetchS2Metadata, S2PaperNotFoundException
+from common.commands.fetch_s2_data import (
+    FetchS2Metadata,
+    S2ApiException,
+    S2ApiRateLimitingException,
+    S2PaperNotFoundException,
+    S2ReferencesNotFoundException
+)
 from scripts.commands import run_command
+
 
 @dataclass
 class Args:
     arxiv_ids: List[str]
     arxiv_ids_file = None
 
-def test_no_s2_paper_raises_exception():
-  command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
-  with pytest.raises(S2PaperNotFoundException):
-    run_command(command)
 
+def test_no_s2_paper_raises_exception():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_resp = Mock()
+        mock_requests.get.return_value = mock_resp
+        mock_resp.ok = False
+        mock_resp.status_code = 404
+
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        with pytest.raises(S2PaperNotFoundException):
+            run_command(command)
+
+
+def test_no_s2_paper_references_raises_exeption():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_resp = Mock()
+        mock_requests.get.return_value = mock_resp
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"references": []}
+
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        with pytest.raises(S2ReferencesNotFoundException):
+            run_command(command)
+
+
+def test_reports_5xx_series_responses():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_requests.get.side_effect = requests.exceptions.HTTPError()
+
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        with pytest.raises(S2ApiException):
+            run_command(command)
+
+
+def test_reports_timeout_errors():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_requests.get.side_effect = requests.exceptions.Timeout()
+
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        with pytest.raises(S2ApiException):
+            run_command(command)
+
+
+def test_reports_rate_limiting():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_resp = Mock()
+        mock_requests.get.return_value = mock_resp
+        mock_resp.ok = False
+        mock_resp.status_code = 429
+
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        with pytest.raises(S2ApiRateLimitingException):
+            run_command(command)
+
+
+def test_reports_generic_exception_for_unhandled_non_2xxs():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_resp = Mock()
+        mock_requests.get.return_value = mock_resp
+        mock_resp.ok = False
+        mock_resp.status_code = 499
+
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        with pytest.raises(S2ApiException):
+            run_command(command)

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -30,7 +30,10 @@ def test_makes_request_over_public_api_in_absence_of_partner_token():
 
             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
             command._mk_api_request("fakeid")
-            mock_requests.get.assert_called_with("https://api.semanticscholar.org/v1/paper/arXiv:fakeid")
+            mock_requests.get.assert_called_with(
+                "https://api.semanticscholar.org/v1/paper/arXiv:fakeid",
+                headers=None
+            )
 
 
 def test_makes_request_over_partner_api_when_token_present():


### PR DESCRIPTION
We had limited finesse in handling different classes of
errors coming back from the S2 public API.

This changeset distinguishes between the existing
4XX series errors, including API rate limiting, as well
as capturing previously unhandled error classes, such
as 5XX-series and timeouts.

The command has also been extended to allow use
of a partner API token (as-yet unfurnished), to identify
as a "partner" with less restricted rate limits (something
we're currently seeing).