### PR TITLE
Pipeline: Bug fix: fix deletion of intermediate files after entity batches that fail

### DIFF
--- a/data-processing/common/commands/base.py
+++ b/data-processing/common/commands/base.py
@@ -136,7 +136,9 @@ def read_arxiv_ids_from_file(path: Path) -> List[ArxivId]:
         for l in arxiv_ids_file:
             comment_start = l.find("#")
             if comment_start != -1:
-                arxiv_ids.append(l[:comment_start].strip())
+                arxiv_id_or_nothing = l[:comment_start].strip()
+                if arxiv_id_or_nothing != "":
+                    arxiv_ids.append(arxiv_id_or_nothing)
             else:
                 arxiv_ids.append(l.strip())
 

--- a/data-processing/common/commands/locate_entities.py
+++ b/data-processing/common/commands/locate_entities.py
@@ -230,6 +230,10 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
         raster_output_dir: Optional[str] = None
         diffs_output_dir: Optional[str] = None
 
+        # Iteration state
+        batch_index = -1
+        iteration_id = None
+
         def next_batch() -> List[str]:
             """
             Get the next batch of entities to process. First tries to sample a batch from
@@ -244,12 +248,12 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
 
         def _cleanup_from_last_batch() -> None:
             " Clean up output directories from the last batch. "
-            if not self.args.keep_intermediate_files:
+            if batch_index > -1 and not self.args.keep_intermediate_files:
                 logging.debug(  # pylint: disable=logging-not-lazy
                     "Deleting intermediate files used to locate entities (i.e., colorized "
                     + "sources, compilation results, and rasters) for paper %s iteration %s",
                     item.arxiv_id,
-                    iteration_id,
+                    iteration_id or "''",
                 )
                 intermediate_files_dirs = [
                     colorized_tex_dir,
@@ -262,9 +266,7 @@ class LocateEntitiesCommand(ArxivBatchCommand[LocationTask, HueLocationInfo], AB
                         file_utils.clean_directory(dir_)
                         os.rmdir(dir_)
 
-        batch_index = -1
         while len(to_process) > 0 or len(to_process_alone) > 0:
-
             if batch_index > -1:
                 _cleanup_from_last_batch()
 


### PR DESCRIPTION
#218 was designed to circumvent out-of-space errors by deleting the overabundance of intermediate files produced by the pipeline (paper rasters, copies of compiled TeX, etc.) when it localizes entities.

While the PR did succeed in deleting intermediate files, it failed to delete these files when there was a failure in entity detection, like a failed LaTeX compilation.

This PR fixes this issue, ensuring that the intermediate files are always deleted, regardless of whether a failure occurred for one batch of entities.

Addresses issue: https://github.com/allenai/scholar/issues/26607