### PR TITLE
Retry logic and retryable exit code for Arxiv fetch failures

### DIFF
--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -475,10 +475,7 @@ if __name__ == "__main__":
                 # The pipeline digest must be updated after each arXiv ID is processed, because the
                 # digest for a paper cannot be computed once the paper's data is deleted.
                 pipeline_digest.update(digest_for_paper)
-            except S2ApiException as e:
-                logging.exception(f"Retryable Failure processing id: {arxiv_id}")
-                exit(RETRYABLE_FAILURE_RETURN_CODE)
-            except FetchFromArxivException as e:
+            except (FetchFromArxivException, S2ApiException) as e:
                 logging.exception(f"Retryable Failure processing id: {arxiv_id}")
                 exit(RETRYABLE_FAILURE_RETURN_CODE)
             finally:

--- a/data-processing/tests/common/commands/test_fetch_arxiv_sources.py
+++ b/data-processing/tests/common/commands/test_fetch_arxiv_sources.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import List, Optional
+from unittest.mock import call, patch
+
+import pytest
+
+from common.commands.fetch_arxiv_sources import (
+    BACKOFF_FETCH_DELAY,
+    DEFAULT_FETCH_DELAY,
+    FetchArxivSources,
+    MAX_FETCH_ATTEMPTS
+)
+from common.fetch_arxiv import FetchFromArxivException
+from scripts.commands import run_command
+
+
+@dataclass
+class Args:
+    arxiv_ids: List[str]
+    arxiv_ids_file: Optional[str]
+    source: str
+    s3_bucket: Optional[str]
+
+
+def test_makes_up_to_k_attempts_to_fetch_from_arxiv():
+    with patch("common.commands.fetch_arxiv_sources.time.sleep") as mock_sleep:
+        with patch("common.commands.fetch_arxiv_sources.fetch_from_arxiv") as mock_fetch:
+            mock_fetch.side_effect = FetchFromArxivException()
+            args = Args(
+                arxiv_ids=["fakeid"],
+                arxiv_ids_file=None,
+                source="arxiv",
+                s3_bucket=None
+            )
+            command = FetchArxivSources(args)
+
+            with pytest.raises(FetchFromArxivException):
+                run_command(command)
+
+            assert mock_fetch.call_count == MAX_FETCH_ATTEMPTS
+            assert mock_sleep.call_args_list == [
+                call(BACKOFF_FETCH_DELAY,),
+                call(BACKOFF_FETCH_DELAY,),
+                call(BACKOFF_FETCH_DELAY,),
+            ]
+
+
+def test_breaks_retry_loop_as_soon_as_successful_fetch_from_arxiv():
+    with patch("common.commands.fetch_arxiv_sources.time.sleep") as mock_sleep:
+        with patch("common.commands.fetch_arxiv_sources.fetch_from_arxiv") as mock_fetch:
+            mock_fetch.return_value = "Some result"
+            args = Args(
+                arxiv_ids=["fakeid"],
+                arxiv_ids_file=None,
+                source="arxiv",
+                s3_bucket=None
+            )
+            command = FetchArxivSources(args)
+
+            run_command(command)
+
+            assert mock_fetch.call_count == 1
+            assert mock_sleep.call_count == 1
+
+

--- a/data-processing/tests/common/test_fetch_arxiv.py
+++ b/data-processing/tests/common/test_fetch_arxiv.py
@@ -1,0 +1,70 @@
+from unittest.mock import Mock, patch
+import urllib3
+
+import pytest
+import requests
+
+from common.fetch_arxiv import FetchFromArxivException, fetch_from_arxiv
+
+
+def test_raises_appropriate_exception_if_request_fails_outright():
+    with patch("common.fetch_arxiv.save_source_archive") as mock_save_source:
+        with patch("common.fetch_arxiv.requests") as mock_requests:
+            mock_requests.get.side_effect = urllib3.exceptions.ProtocolError()
+
+            with pytest.raises(FetchFromArxivException):
+                fetch_from_arxiv("fakeid")
+
+            assert not mock_save_source.called
+
+
+        with patch("common.fetch_arxiv.requests") as mock_requests:
+            mock_requests.get.side_effect = requests.exceptions.HTTPError()
+
+            with pytest.raises(FetchFromArxivException):
+                fetch_from_arxiv("fakeid")
+
+            assert not mock_save_source.called
+
+
+def test_raises_regular_error_in_case_of_404():
+    with patch("common.fetch_arxiv.save_source_archive") as _:
+        with patch("common.fetch_arxiv.requests") as mock_requests:
+            mock_resp = Mock()
+            mock_resp.ok = False
+            mock_resp.status_code = 404
+            mock_requests.get.return_value = mock_resp
+
+            try:
+                fetch_from_arxiv("fakeid")
+            except Exception as e:
+                assert not isinstance(e, FetchFromArxivException)
+            else:
+                assert False, "Expected to receive an exception"
+
+
+def test_raises_appropriate_exception_if_other_non_ok_response():
+    with patch("common.fetch_arxiv.save_source_archive") as _:
+        with patch("common.fetch_arxiv.requests") as mock_requests:
+            mock_resp = Mock()
+            mock_resp.ok = False
+            mock_resp.status_code = 403
+            mock_requests.get.return_value = mock_resp
+
+            with pytest.raises(FetchFromArxivException):
+                fetch_from_arxiv("fakeid")
+
+
+def test_saves_source_if_all_good():
+    with patch("common.fetch_arxiv.save_source_archive") as mock_save_source:
+        with patch("common.fetch_arxiv.requests") as mock_requests:
+            mock_resp = Mock()
+            mock_resp.ok = True
+            mock_resp.status_code = 200
+            mock_resp.content = "i am some content"
+            mock_requests.get.return_value = mock_resp
+
+            fetch_from_arxiv("fakeid")
+
+            mock_save_source.assert_called_with("fakeid", "i am some content", None)
+


### PR DESCRIPTION
We're seeing a lot of "peer closed connection" errors when requesting
data from ArXiv. This may or may not be rate limiting; however we should
not treat it as an unrecoverable error.

This changeset does two things:

1) It intercepts expected failure modes in `fetch_from_arxiv`, raising a new error type
that can be caught in a driver script and used to provide a retryable exit code to
`scholarphi-pipeline`

2) Performs an in-process retry loop with more generous backoff delay.

This won't solve our woes but will allow us to at least retry sensibly.