### PR TITLE
Remove link annotation borders & cache-bust viewer JS and CSS

### DIFF
--- a/ui/public/viewer.css
+++ b/ui/public/viewer.css
@@ -84,6 +84,10 @@
   position: absolute;
 }
 
+.annotationLayer .linkAnnotation {
+  border: none !important;
+}
+
 .annotationLayer .linkAnnotation > a,
 .annotationLayer .buttonWidgetAnnotation.pushButton > a {
   position: absolute;

--- a/ui/public/viewer.html
+++ b/ui/public/viewer.html
@@ -36,8 +36,8 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 
     <link rel="icon" href="images/favicon.png" sizes="32x32">
-    <link rel="stylesheet" href="viewer.css">
-    
+    <link rel="stylesheet" href="viewer.css?cb=<%= cacheBust %>">
+
     <!-- Semantic Reader specific -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
 
@@ -87,7 +87,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <script>PDF_WORKER_SRC="pdf.worker.min.js";</script>
-<script src="pdf.viewer.js"></script>
+<script src="pdf.viewer.js?cb=<%= cacheBust %>"></script>
 
 
   </head>

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -45,7 +45,10 @@ module.exports = (env, argv) => {
         {
           inject: true,
           template: './public/viewer.html',
-          excludeChunks: ['list']
+          templateParameters: {
+            cacheBust: Math.random().toString(36).substring(7)
+          },
+          excludeChunks: ['list'],
         }
       ),
       new HtmlWebpackPlugin(
@@ -56,14 +59,14 @@ module.exports = (env, argv) => {
           excludeChunks: ['reader']
         }
       ),
-      // This copies everything that isn't `index.html` from `public/` into the build output
+      // This copies everything that isn't an HTML file from `public/` into the build output
       // directory.
       new CopyPlugin({
         patterns: [
           {
             from: 'public/**/*',
             filter: (absPathToFile) => {
-              return absPathToFile !== path.resolve(__dirname, 'public', 'index.html');
+              return !absPathToFile.endsWith(".html");
             },
             transformPath: (p) => p.replace(/^public\//, ''),
           },


### PR DESCRIPTION
No more green/red borders around the PDF links. This should roll out to clients without needing them to manually clear caches, too, as I've added random query param strings for cache-busting.