### PR TITLE
Deduped payload

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -174,7 +174,7 @@ export const plugin = {
         const entityTypes = request.query.type as EntityType[];
         let res;
         try {
-          res = await dbConnection.getEntitiesForPaper(paperSelector, entityTypes);
+          res = await dbConnection.getEntitiesForPaper(paperSelector, entityTypes, true);
         } catch (e) {
           console.log(e);
         }

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -199,7 +199,7 @@ export const plugin = {
     server.route({
       method: "GET",
       path: "papers/{paperSelector}/entities-deduped",
-      handler: async (request) => {
+      handler: async (request, h) => {
         const paperSelector = parsePaperSelector(request.params.paperSelector);
         // Runtime type-checked during validation.
         const entityTypes = request.query.type as EntityType[];
@@ -208,6 +208,7 @@ export const plugin = {
           res = await dbConnection.getDedupedEntitiesForPaper(paperSelector, entityTypes);
         } catch (e) {
           console.log(e);
+          return h.response().code(500);
         }
         return { data: res };
       },

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -537,6 +537,12 @@ export class Connection {
       })
       .map((validationResult) => validationResult.value as Entity);
 
+    /**
+     * To provide a deduped copy of shared data between symbol instances, we
+     * identify each symbol by its "disambiguated" id (currently the `mathml` attribute).
+     * An arbitrary symbol entity from within each `mathml` is chosen as an exemplar from
+     * which to look up supporting data that is identical across instances.
+     */
     const disambiguatedSymbolIdsToExemplarEntityIds = entities
       .filter((row) => isSymbol(row))
       .reduce(

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -569,6 +569,12 @@ export class Connection {
       }
     );
 
+    if (entityTypes.indexOf("symbol") === -1 && entityTypes.length > 0) {
+      return {
+        entities
+      }
+    }
+
     const dedupedSymbolData = await this._knex("entitydata")
       .select("entity_id", "key", "value")
       .orderBy("id", "asc")

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -263,10 +263,10 @@ export class Connection {
     };
 
     if (isSymbol(entity)) {
-      entity.attributes.disambiguated_id = entity.attributes.mathml
+      entity.attributes.disambiguated_id = entity.attributes.mathml;
     }
 
-    return entity
+    return entity;
   }
 
   async getEntitiesForPaper(paperSelector: PaperSelector, entityTypes: EntityType[], includeDuplicateSymbolData: boolean, version?: number) {

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -152,6 +152,7 @@ export const BASE_ENTITY_ATTRIBUTE_KEYS = [
   "tags",
 ];
 
+
 /**
  * While it is not described with types here, Relationships must be key-value pairs, where the values
  * are either 'Relationship' or a list of 'Relationship's.
@@ -221,6 +222,33 @@ export type GenericRelationships = {
   [key: string]: Relationship | Relationship[];
 };
 
+
+/**
+ * Represents the entity data fields that are identical between every instance
+ * of a given symbol.
+ * Defined here so that we can reduce the order of space consumption in the payload.
+ */
+export const sharedSymbolFields = [
+  "defining_formula_equations",
+  "defining_formulas",
+  "definition_sentences",
+  "definition_texs",
+  "definitions",
+  "snippets",
+  "snippet_sentences",
+  "sources"
+]
+export interface SharedSymbolData {
+  defining_formula_equations: string[];  // entity id
+  defining_formulas: string[];  // tex-bearing formula text
+  definition_sentences: string[];
+  definition_texs: string[];
+  definitions: string[];
+  snippets: string[];  // tex-bearing sentence text
+  snippet_sentences: string[];  // entity id
+  sources: string[];
+}
+
 /**
  * 'Symbol' is an example of how to define a new entity type with custom attributes
  * and relationships. Note that a full custom entity definition includes:
@@ -235,6 +263,7 @@ export interface Symbol extends BaseEntity {
 }
 
 export interface SymbolAttributes extends BaseEntityAttributes {
+  disambiguated_id: string | null;
   tex: string | null;
   type: "identifier" | "function" | "operator";
   mathml: string | null;

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -152,7 +152,6 @@ export const BASE_ENTITY_ATTRIBUTE_KEYS = [
   "tags",
 ];
 
-
 /**
  * While it is not described with types here, Relationships must be key-value pairs, where the values
  * are either 'Relationship' or a list of 'Relationship's.
@@ -221,7 +220,6 @@ export interface GenericAttributes {
 export type GenericRelationships = {
   [key: string]: Relationship | Relationship[];
 };
-
 
 /**
  * Represents the entity data fields that are identical between every instance

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -115,6 +115,7 @@ attributes = attributes
       {
         is: "symbol",
         then: Joi.object().keys({
+          disambiguated_id: stringAttribute,
           tex: stringAttribute,
           type: stringAttribute,
           mathml: stringAttribute,


### PR DESCRIPTION
Opens a new endpoint to test deduplication of shared data
across instances of a given symbol.

We identify a canonical ID for each symbol, and generate a lookup
table with a single copy of data that are currently duplicated
quadratically at the DB across its instances.

This PR does not change the persistence layer itself, but
defines a desired API response payload shape, and tactically
modified the SQL we are running to build up said payload.

The endpoint can be accessed at:

`v0/papers/<id>/entities-deduped?type=all|symbol`

The response now looks like:

```json
{
    "data": {
        "entities": [ /* as it was minus shared data */ ],
        "sharedSymbolData": {
            someDisambiguatedId: {
                  "defining_formula_equations": [],
                  "defining_formulas": [],
                  "definition_sentences": [],
                  "definition_texs": [],
                  "definitions": [],
                  "snippets": [],
                  "snippet_sentences": [],
                 "sources": [] 
        },
        /* other disambiguated members */
    }
}
```

Symbol entities now include a new member, `disambiguatedId`,
in their attributes to allow for the lookup.