### PR TITLE
Optionally omit certain fields from entity responses

### DIFF
--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -331,8 +331,8 @@ export class Connection {
       }
     );
     const entityDataColumns = slim
-    ? ["entity_id", "key", "value", "item_type", "of_list", "relation_type"]
-    : ["entity_id", "source", "key", "value", "item_type", "of_list", "relation_type"];
+    ? ["entity.id AS entity_id", "key", "value", "item_type", "of_list", "relation_type"]
+    : ["entity.id AS entity_id", "entitydata.source AS source", "key", "value", "item_type", "of_list", "relation_type"];
     const entityDataRows: EntityDataRow[] = await this._knex("entitydata")
       .select(entityDataColumns)
       .join("entity", { "entitydata.entity_id": "entity.id" })

--- a/api/src/db-connection.ts
+++ b/api/src/db-connection.ts
@@ -181,7 +181,7 @@ export class Connection {
    * relationships may need to be cleaned, as they contain *anything* that was found in the
    * entity table, which could include junk uploaded by annotators.
    */
-  unpackEntityDataRows(rows: Omit<EntityDataRow, "id">[]) {
+  unpackEntityDataRows(rows: Omit<EntityDataRow, "id">[], slim: boolean = false) {
     const attributes: GenericAttributes = {};
     const relationships: GenericRelationships = {};
     for (const row of rows) {
@@ -215,7 +215,10 @@ export class Connection {
        * Read relationships.
        */
       if (row.item_type === "relation-id" && row.relation_type !== null) {
-        const relationship = { type: row.relation_type, id: row.value };
+        // optionally return a more compact representation for relationships
+        const relationship = slim
+          ? { id: row.value }
+          : { type: row.relation_type, id: row.value };
         if (row.of_list) {
           if (relationships[row.key] === undefined) {
             relationships[row.key] = [];
@@ -235,12 +238,13 @@ export class Connection {
   createEntityObjectFromRows(
     entityRow: EntityRow,
     boundingBoxRows: Omit<BoundingBoxRow, "id">[],
-    entityDataRows: Omit<EntityDataRow, "id">[]
+    entityDataRows: Omit<EntityDataRow, "id">[],
+    slim?: boolean,
   ): Entity {
     const boundingBoxes = this.createBoundingBoxes(boundingBoxRows);
 
     const { attributes, relationships } = this.unpackEntityDataRows(
-      entityDataRows
+      entityDataRows, slim
     );
 
     return {
@@ -259,7 +263,7 @@ export class Connection {
     };
   }
 
-  async getEntitiesForPaper(paperSelector: PaperSelector, entityTypes: EntityType[], version?: number) {
+  async getEntitiesForPaper(paperSelector: PaperSelector, entityTypes: EntityType[], slim: boolean, version?: number) {
     if (version === undefined) {
       try {
         let latestVersion = await this.getLatestPaperDataVersion(paperSelector);
@@ -272,8 +276,11 @@ export class Connection {
       }
     }
 
+    const entityColumns = slim
+      ? ["entity.paper_id AS paper_id", "id", "type"]
+      : ["entity.paper_id AS paper_id", "id", "version", "type", "source"];
     const entityRows: EntityRow[] = await this._knex("entity")
-      .select("entity.paper_id AS paper_id", "id", "version", "type", "source")
+      .select(entityColumns)
       .join("paper", { "paper.s2_id": "entity.paper_id" })
       .where({ ...paperSelector, version }).andWhere(builder => {
         if (entityTypes.length > 0) {
@@ -285,19 +292,13 @@ export class Connection {
 
     const entityIds = entityRows.map(e => e.id);
 
+    const boundingBoxColumns = slim
+    ? ["id", "entity_id", "page", "left", "top", "width", "height"]
+    : ["id", "entity_id", "source", "page", "left", "top", "width", "height"];
     let boundingBoxRows: BoundingBoxRow[];
     try {
       boundingBoxRows = await this._knex("boundingbox")
-        .select(
-          "id",
-          "entity_id",
-          "source",
-          "page",
-          "left",
-          "top",
-          "width",
-          "height"
-        )
+        .select(boundingBoxColumns)
         .whereIn("entity_id", entityIds);
     } catch (e) {
       console.log(e);
@@ -319,17 +320,11 @@ export class Connection {
         [entity_id: string]: BoundingBoxRow[];
       }
     );
-
+    const entityDataColumns = slim
+    ? ["entity_id", "key", "value", "item_type", "of_list", "relation_type"]
+    : ["entity_id", "source", "key", "value", "item_type", "of_list", "relation_type"];
     const entityDataRows: EntityDataRow[] = await this._knex("entitydata")
-      .select(
-        "entity_id",
-        "source",
-        "key",
-        "value",
-        "item_type",
-        "of_list",
-        "relation_type"
-      )
+      .select(entityDataColumns)
       .whereIn("entity_id", entityIds)
       /*
        * Order by entity ID to ensure that items from lists are retrieved in
@@ -365,7 +360,8 @@ export class Connection {
         return this.createEntityObjectFromRows(
           entityRow,
           boundingBoxRowsForEntity,
-          entityDataRowsForEntity
+          entityDataRowsForEntity,
+          slim
         );
       })
       /*

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -123,7 +123,7 @@ export interface BaseEntity {
  */
 export interface BaseEntityAttributes {
   version: number;
-  source: string;
+  source: string; // TODO: technically optional for outgoing responses
   bounding_boxes: BoundingBox[];
   /**
    * Additional data for this entity in the form of arbitrary strings. For instance, there could be
@@ -136,21 +136,8 @@ export interface BaseEntityAttributes {
    * when prototyping new features, as it allows the data to be changed in the database without
    * continually updating these types.
    */
-  tags: string[];
+  tags?: string[];
 }
-
-/**
- * List of base entity attribute keys. Update this as 'BaseEntityAttributes' updates. This list
- * lets a program check statically whether an attribute on an entity is a custom attribute.
- */
-export const BASE_ENTITY_ATTRIBUTE_KEYS = [
-  "id",
-  "type",
-  "version",
-  "source",
-  "bounding_boxes",
-  "tags",
-];
 
 /**
  * While it is not described with types here, Relationships must be key-value pairs, where the values
@@ -159,7 +146,7 @@ export const BASE_ENTITY_ATTRIBUTE_KEYS = [
 export interface Relationships {}
 
 export interface Relationship {
-  type: string;
+  type?: string;
   id: string | null;
 }
 

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -49,7 +49,7 @@ export const arxivOnlySelector = Joi.object({
 
 const boundingBox = Joi.object({
   page: Joi.number().integer().min(0),
-  source: Joi.string(),
+  source: Joi.string().optional(),
   left: Joi.number(),
   top: Joi.number(),
   width: Joi.number(),
@@ -65,8 +65,9 @@ export let attributes = Joi.object({
   /*
    * Source is required on both POST and PATCH requests. It is required for PATCH requests because
    * the database logs the 'source' of updated attributes and bounding boxes.
+   * TODO: Split this for GETs and POST/PATCHes -- This is also used for outgoing API responses, which don't need to include source
    */
-  source: Joi.string().required(),
+  source: Joi.string().optional(),
   bounding_boxes: Joi.array().items(boundingBox),
   tags: Joi.array().items(Joi.string()),
 });
@@ -172,7 +173,7 @@ export let relationships = Joi.object();
  */
 const oneToOneRelationship = (type: string) => {
   return Joi.object({
-    type: Joi.string().required().valid(type),
+    type: Joi.string().optional().valid(type),
     id: Joi.string().required().allow(null),
   }).default({ type, id: null });
 };
@@ -180,7 +181,7 @@ const oneToManyRelationship = (type: string) => {
   return Joi.array()
     .items(
       Joi.object({
-        type: Joi.string().required().valid(type),
+        type: Joi.string().optional().valid(type),
         id: Joi.string().required(),
       })
     )

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -127,19 +127,6 @@ export interface BaseEntityAttributes {
 }
 
 /**
- * List of base entity attribute keys. Update this as 'BaseEntityAttributes' updates. This list
- * lets a program check statically whether an attribute on an entity is a custom attribute.
- */
-export const BASE_ENTITY_ATTRIBUTE_KEYS = [
-  "id",
-  "type",
-  "version",
-  "source",
-  "bounding_boxes",
-  "tags",
-];
-
-/**
  * While it is not described with types here, Relationships must be key-value pairs, where the values
  * are either 'Relationship' or a list of 'Relationship's.
  */


### PR DESCRIPTION
This branch changes 3 things about the current entity response:
- `source` fields are removed from entities and bounding boxes. These are sent by the UI when modifying entities, but the UI doesn't really do anything with this information besides applying a CSS style on one component (which is applied for 99% of entities).
- The entity's `version` field is similarly removed because the UI does nothing with it
- Relationships omit the `type` field because they tend to only relate to one type of thing (and it's often in the name of the relationship).

It's all behind a `slim` query param that's `false` by default so it doesn't break the UI.

In a smaller case, it's good for about 27kB savings:
`GET http://localhost:3000/api/v0/papers/arxiv:1601.00978v1/entities?type=all&slim=false` - 188.37kB
`GET http://localhost:3000/api/v0/papers/arxiv:1601.00978v1/entities?type=all&slim=true` - 161.93kB

In a much larger case, it's good for about 14MB savings:
`GET http://localhost:3000/api/v0/papers/arxiv:2101.12018v1/entities?type=all&slim=false` - 58.14MB
`GET http://localhost:3000/api/v0/papers/arxiv:2101.12018v1/entities?type=all&slim=true` - 44.18MB