### PR TITLE
Don't wrap the entity response with an extra field

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -224,7 +224,7 @@ export const plugin = {
           console.log(e);
           return h.response().code(500);
         }
-        return { data: res };
+        return res;
       },
       options: {
         validate: {


### PR DESCRIPTION
This effectively makes `entities` and `sharedSymbolData` the two top-level fields within the response and saves a couple more bytes.