### PR TITLE
don't return tag fields when serving deduped entities

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -224,6 +224,13 @@ export const plugin = {
           console.log(e);
           return h.response().code(500);
         }
+        // tags are unused, don't return them
+        res = res.entities.map(e => {
+          if (e.attributes.tags) {
+            delete e.attributes.tags;
+          }
+          return e;
+        });
         return res;
       },
       options: {


### PR DESCRIPTION
Good for a few kb in most cases and a solid 800kb in my worst-case example (drops from 4.4MB to 3.6MB)