### PR TITLE
Use the deduped entities API for loading the entities

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -735,7 +735,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
           areCitationsLoading: true
         });
         const loadingStartTime = performance.now();
-        const entities = await api.getDedupedEntities(this.props.paperId.id);
+        const entities = await api.getDedupedEntities(this.props.paperId.id, true);
         this.setState({
           entities: stateUtils.createRelationalStoreFromArray(entities, "id"),
         });

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -734,13 +734,8 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
         this.setState({
           areCitationsLoading: true
         });
-        let getAllEntities = false;
-        const qs = queryString.parse(window.location.search);
-        if (qs.showAll && qs.showAll === "true") {
-          getAllEntities = true;
-        }
         const loadingStartTime = performance.now();
-        const entities = await api.getEntities(this.props.paperId.id, getAllEntities);
+        const entities = await api.getDedupedEntities(this.props.paperId.id);
         this.setState({
           entities: stateUtils.createRelationalStoreFromArray(entities, "id"),
         });

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -218,6 +218,19 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
   };
 }
 
+
+/**
+ * This API returns a compacted representation of the paper's entities and their relationships.
+ * Certain fields of Symbol entity data are pulled into a separate `sharedSymbolData` map,
+ * which is organized by the Symbols' `attributes.disambiguated_id` value.
+ *
+ * NOTE: Currently, this function passes the response through a transform function to make
+ * it compatible with the existing UI code.
+ * 
+ * @param arxivId arXiv ID of the viewed paper
+ * @param getAllEntities `true` retrieves entities of all types, `false` retrieves only citations
+ * @returns
+ */
 export async function getDedupedEntities(arxivId: string, getAllEntities?: boolean) {
   const params = getAllEntities ? {
     type: ENTITY_API_ALL

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -11,7 +11,14 @@ import {
   Paper,
   Paginated,
   PaperIdWithEntityCounts,
+  EntityGetResponse,
+  Citation,
+  Equation,
+  Sentence,
+  Symbol,
+  Term,
 } from "./types";
+import { Entity as DedupedEntity, DedupedEntityResponse, isCitation, isEquation, isSentence, isSymbol, isTerm, toLegacyRelationship } from "./deduped";
 
 const token = cookie.parse(document.cookie)["readerAdminToken"];
 
@@ -70,6 +77,134 @@ export async function getEntities(arxivId: string, getAllEntities?: boolean) {
     axios.get(`/api/v0/papers/arxiv:${arxivId}/entities`, { params })
   );
   return ((data as any).data || []) as Entity[];
+}
+
+// This translates from the entities-deduped API's response to the legacy
+// super-duplicated API response, as a compat shim.
+// TODO: phase this out in favor of using a more efficient data model in the reader app.
+function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
+  // TODO: Improve error handling; this just pulls the eject handle if the response is an API error
+  if (!!(response as any).error) {
+    throw "API error: " + (response as any).error;
+  }
+  const entities: Entity[] = response.entities.map((deduped: DedupedEntity) => {
+    if (isCitation(deduped)) {
+      const citation: Citation = {
+        id: deduped.id,
+        type: 'citation',
+        attributes: {
+          bounding_boxes: deduped.attributes.bounding_boxes,
+          paper_id: deduped.attributes.paper_id,
+          source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
+          tags: []
+        },
+        relationships: {}
+      };
+      return citation;
+    } else if (isEquation(deduped)) {
+      const equation: Equation = {
+        id: deduped.id,
+        type: 'equation',
+        attributes: {
+          bounding_boxes: deduped.attributes.bounding_boxes,
+          source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
+          tags: [],
+          tex: deduped.attributes.tex
+        },
+        relationships: {}
+      };
+      return equation;
+    } else if (isSentence(deduped)) {
+      const sentence: Sentence = {
+        id: deduped.id,
+        type: 'sentence',
+        attributes: {
+          bounding_boxes: deduped.attributes.bounding_boxes,
+          source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
+          tags: [],
+          tex: deduped.attributes.tex,
+          tex_start: deduped.attributes.tex_start,
+          tex_end: deduped.attributes.tex_end,
+          text: deduped.attributes.text,
+        },
+        relationships: {}
+      };
+      return sentence;
+    } else if (isSymbol(deduped)) {
+      const mathml = deduped.attributes.disambiguated_id;
+      const symbol: Symbol = {
+        id: deduped.id,
+        type: 'symbol',
+        attributes: {
+          bounding_boxes: deduped.attributes.bounding_boxes,
+          source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
+          tags: [],
+          tex: deduped.attributes.tex,
+          type: deduped.attributes.type,
+          mathml: deduped.attributes.mathml,
+          mathml_near_matches: deduped.attributes.mathml_near_matches,
+          diagram_label: deduped.attributes.diagram_label,
+          is_definition: deduped.attributes.is_definition,
+          nicknames: deduped.attributes.nicknames,
+          definitions: response.sharedSymbolData[mathml]?.definitions || [],
+          defining_formulas: response.sharedSymbolData[mathml]?.defining_formulas || [],
+          passages: deduped.attributes.passages,
+          snippets: response.sharedSymbolData[mathml]?.snippets || [],
+        },
+        relationships: {
+          equation: toLegacyRelationship(deduped.relationships.equation, 'equation'),
+          children: deduped.relationships.children.map(c => toLegacyRelationship(c, 'symbol')),
+          parent: toLegacyRelationship(deduped.relationships.parent, 'symbol'),
+          sentence: toLegacyRelationship(deduped.relationships.sentence, 'sentence'),
+          nickname_sentences: deduped.relationships.nickname_sentences.map(n => toLegacyRelationship(n, 'sentence')),
+          defining_formula_equations: (response.sharedSymbolData[mathml]?.defining_formula_equations || []).map(s => toLegacyRelationship(s, 'equation')),
+          definition_sentences: (response.sharedSymbolData[mathml]?.definition_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
+          snippet_sentences: (response.sharedSymbolData[mathml]?.snippet_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
+        }
+      };
+      return symbol;
+    } else if (isTerm(deduped)) {
+      const term: Term = {
+        id: deduped.id,
+        type: 'term',
+        attributes: {
+          bounding_boxes: deduped.attributes.bounding_boxes,
+          name: deduped.attributes.name,
+          source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
+          tags: [],
+          term_type: deduped.attributes.term_type,
+          definitions: deduped.attributes.definitions,
+          definition_texs: deduped.attributes.definition_texs,
+          sources: deduped.attributes.sources,
+          snippets: deduped.attributes.snippets,
+        },
+        relationships: {
+          sentence: toLegacyRelationship(deduped.relationships.sentence, 'sentence'),
+          definition_sentences: (deduped.relationships.definition_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
+          snippet_sentences: (deduped.relationships.snippet_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
+        }
+      };
+      return term;
+    }
+    // There's a new kind of entity that hasn't been implemented in the UI.
+    throw "Unknown entity type";
+  });
+  return {
+    data: entities
+  };
+}
+
+export async function getDedupedEntities(arxivId: string) {
+  const data = await doGet(
+    axios.get<EntityGetResponse>(
+      `/api/v0/papers/arxiv:${arxivId}/entities-deduped`,
+      {
+        //@ts-ignore -- TODO: this pattern works in other projects, is there a version issue somewhere?
+        transformResponse: [].concat(axios.defaults.transformResponse).concat(undedupeResponse)
+      }
+    )
+  );
+  return data.data || [];
 }
 
 export async function postEntity(
@@ -168,5 +303,5 @@ async function doGet<T>(get: Promise<AxiosResponse<T>>) {
   } catch (error) {
     console.error("API Error:", error);
   }
-  return null;
+  throw "API Error";
 }

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -18,7 +18,16 @@ import {
   Symbol,
   Term,
 } from "./types";
-import { Entity as DedupedEntity, DedupedEntityResponse, isCitation, isEquation, isSentence, isSymbol, isTerm, toLegacyRelationship } from "./deduped";
+import {
+  Entity as DedupedEntity,
+  DedupedEntityResponse,
+  isCitation,
+  isEquation,
+  isSentence,
+  isSymbol,
+  isTerm,
+  toLegacyRelationship
+} from "./deduped";
 
 const token = cookie.parse(document.cookie)["readerAdminToken"];
 
@@ -226,7 +235,7 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
  *
  * NOTE: Currently, this function passes the response through a transform function to make
  * it compatible with the existing UI code.
- * 
+ *
  * @param arxivId arXiv ID of the viewed paper
  * @param getAllEntities `true` retrieves entities of all types, `false` retrieves only citations
  * @returns

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -140,7 +140,8 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
       };
       return sentence;
     } else if (isSymbol(deduped)) {
-      const mathml = deduped.attributes.disambiguated_id;
+       // empty string is a safe default, there shouldn't be sharedSymbolData for empty string.
+      const disambiguatedId = deduped.attributes.disambiguated_id || '';
       const symbol: Symbol = {
         id: deduped.id,
         type: 'symbol',
@@ -155,11 +156,11 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
           diagram_label: deduped.attributes.diagram_label,
           is_definition: deduped.attributes.is_definition,
           nicknames: deduped.attributes.nicknames,
-          definitions: response.sharedSymbolData[mathml]?.definitions || [],
+          definitions: response.sharedSymbolData[disambiguatedId]?.definitions || [],
           defining_formulas:
-            response.sharedSymbolData[mathml]?.defining_formulas || [],
+            response.sharedSymbolData[disambiguatedId]?.defining_formulas || [],
           passages: deduped.attributes.passages,
-          snippets: response.sharedSymbolData[mathml]?.snippets || [],
+          snippets: response.sharedSymbolData[disambiguatedId]?.snippets || [],
         },
         relationships: {
           equation: toLegacyRelationship(
@@ -178,13 +179,13 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
             (n) => toLegacyRelationship(n, 'sentence')
           ),
           defining_formula_equations: (
-            response.sharedSymbolData[mathml]?.defining_formula_equations || []
+            response.sharedSymbolData[disambiguatedId]?.defining_formula_equations || []
           ).map((s) => toLegacyRelationship(s, 'equation')),
           definition_sentences: (
-            response.sharedSymbolData[mathml]?.definition_sentences || []
+            response.sharedSymbolData[disambiguatedId]?.definition_sentences || []
           ).map((s) => toLegacyRelationship(s, 'sentence')),
           snippet_sentences: (
-            response.sharedSymbolData[mathml]?.snippet_sentences || []
+            response.sharedSymbolData[disambiguatedId]?.snippet_sentences || []
           ).map((s) => toLegacyRelationship(s, 'sentence')),
         },
       };

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -194,17 +194,21 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
   };
 }
 
-export async function getDedupedEntities(arxivId: string) {
+export async function getDedupedEntities(arxivId: string, getAllEntities?: boolean) {
+  const params = getAllEntities ? {
+    type: ENTITY_API_ALL
+  } : {};
   const data = await doGet(
     axios.get<EntityGetResponse>(
       `/api/v0/papers/arxiv:${arxivId}/entities-deduped`,
       {
+        params,
         //@ts-ignore -- TODO: this pattern works in other projects, is there a version issue somewhere?
         transformResponse: [].concat(axios.defaults.transformResponse).concat(undedupeResponse)
       }
     )
   );
-  return data.data || [];
+  return data?.data || [];
 }
 
 export async function postEntity(
@@ -303,5 +307,5 @@ async function doGet<T>(get: Promise<AxiosResponse<T>>) {
   } catch (error) {
     console.error("API Error:", error);
   }
-  throw "API Error";
+  return null;
 }

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -96,9 +96,9 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
           bounding_boxes: deduped.attributes.bounding_boxes,
           paper_id: deduped.attributes.paper_id,
           source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
-          tags: []
+          tags: [],
         },
-        relationships: {}
+        relationships: {},
       };
       return citation;
     } else if (isEquation(deduped)) {
@@ -109,9 +109,9 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
           bounding_boxes: deduped.attributes.bounding_boxes,
           source: 'tex-pipeline', // hardcoded since most everything comes out of the tex pipeline
           tags: [],
-          tex: deduped.attributes.tex
+          tex: deduped.attributes.tex,
         },
-        relationships: {}
+        relationships: {},
       };
       return equation;
     } else if (isSentence(deduped)) {
@@ -127,7 +127,7 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
           tex_end: deduped.attributes.tex_end,
           text: deduped.attributes.text,
         },
-        relationships: {}
+        relationships: {},
       };
       return sentence;
     } else if (isSymbol(deduped)) {
@@ -147,20 +147,37 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
           is_definition: deduped.attributes.is_definition,
           nicknames: deduped.attributes.nicknames,
           definitions: response.sharedSymbolData[mathml]?.definitions || [],
-          defining_formulas: response.sharedSymbolData[mathml]?.defining_formulas || [],
+          defining_formulas:
+            response.sharedSymbolData[mathml]?.defining_formulas || [],
           passages: deduped.attributes.passages,
           snippets: response.sharedSymbolData[mathml]?.snippets || [],
         },
         relationships: {
-          equation: toLegacyRelationship(deduped.relationships.equation, 'equation'),
-          children: deduped.relationships.children.map(c => toLegacyRelationship(c, 'symbol')),
+          equation: toLegacyRelationship(
+            deduped.relationships.equation,
+            'equation'
+          ),
+          children: deduped.relationships.children.map(
+            (c) => toLegacyRelationship(c, 'symbol')
+          ),
           parent: toLegacyRelationship(deduped.relationships.parent, 'symbol'),
-          sentence: toLegacyRelationship(deduped.relationships.sentence, 'sentence'),
-          nickname_sentences: deduped.relationships.nickname_sentences.map(n => toLegacyRelationship(n, 'sentence')),
-          defining_formula_equations: (response.sharedSymbolData[mathml]?.defining_formula_equations || []).map(s => toLegacyRelationship(s, 'equation')),
-          definition_sentences: (response.sharedSymbolData[mathml]?.definition_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
-          snippet_sentences: (response.sharedSymbolData[mathml]?.snippet_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
-        }
+          sentence: toLegacyRelationship(
+            deduped.relationships.sentence,
+            'sentence'
+          ),
+          nickname_sentences: deduped.relationships.nickname_sentences.map(
+            (n) => toLegacyRelationship(n, 'sentence')
+          ),
+          defining_formula_equations: (
+            response.sharedSymbolData[mathml]?.defining_formula_equations || []
+          ).map((s) => toLegacyRelationship(s, 'equation')),
+          definition_sentences: (
+            response.sharedSymbolData[mathml]?.definition_sentences || []
+          ).map((s) => toLegacyRelationship(s, 'sentence')),
+          snippet_sentences: (
+            response.sharedSymbolData[mathml]?.snippet_sentences || []
+          ).map((s) => toLegacyRelationship(s, 'sentence')),
+        },
       };
       return symbol;
     } else if (isTerm(deduped)) {
@@ -179,10 +196,17 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
           snippets: deduped.attributes.snippets,
         },
         relationships: {
-          sentence: toLegacyRelationship(deduped.relationships.sentence, 'sentence'),
-          definition_sentences: (deduped.relationships.definition_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
-          snippet_sentences: (deduped.relationships.snippet_sentences || []).map(s => toLegacyRelationship(s, 'sentence')),
-        }
+          sentence: toLegacyRelationship(
+            deduped.relationships.sentence,
+            'sentence'
+          ),
+          definition_sentences: (
+            deduped.relationships.definition_sentences || []
+          ).map((s) => toLegacyRelationship(s, 'sentence')),
+          snippet_sentences: (
+            deduped.relationships.snippet_sentences || []
+          ).map((s) => toLegacyRelationship(s, 'sentence')),
+        },
       };
       return term;
     }
@@ -190,7 +214,7 @@ function undedupeResponse(response: DedupedEntityResponse): EntityGetResponse {
     throw "Unknown entity type";
   });
   return {
-    data: entities
+    data: entities,
   };
 }
 

--- a/ui/src/api/deduped.ts
+++ b/ui/src/api/deduped.ts
@@ -1,0 +1,168 @@
+import { BoundingBox, Relationship as LegacyRelationship } from './types';
+
+export type Nullable<T> = T | null;
+
+/**
+ * Types defined in here are for the entities-deduped endpoint,
+ * and are intentionally less generic.
+ * TODO: Replace existing entity type usages with these
+ */
+
+export interface DedupedEntityResponse {
+  entities: Entity[];
+  sharedSymbolData: { [dedupedMathml: string]: SharedSymbolData };
+}
+
+interface EntityBase {
+  id: string;
+  type: string; // type specifically?
+  attributes: AttributesBase;
+}
+
+export type Entity = Citation | Symbol | Term | Equation | Sentence;
+
+interface AttributesBase {
+  bounding_boxes: BoundingBox[];
+}
+
+type Relationship = { id: string } | string;
+
+export interface Citation extends EntityBase {
+  type: 'citation';
+  attributes: CitationAttributes;
+}
+
+interface CitationAttributes extends AttributesBase {
+  paper_id: Nullable<string>;
+}
+
+export interface Symbol extends EntityBase {
+  type: 'symbol';
+  attributes: SymbolAttributes;
+  relationships: SymbolRelationships;
+}
+
+interface SymbolAttributes extends AttributesBase {
+  tex: Nullable<string>;
+  type: "identifier" | "function" | "operator"; // TODO: This is null too with the deduped endpoint
+  mathml: Nullable<string>;
+  mathml_near_matches: string[];
+  is_definition: Nullable<boolean>;
+  diagram_label: Nullable<string>;
+  /**
+   * This is the ID to use when getting SharedSymbolData for this entity.
+   */
+  disambiguated_id: string;
+  /**
+   * Nicknames for the symbol extracted from the text, no more than a few words long.
+   */
+  nicknames: string[];
+  /**
+   * Other passages from the paper that help explain what this symbol means.
+   */
+  passages: string[];
+}
+
+export interface Term extends EntityBase {
+  type: 'term';
+  attributes: TermAttributes;
+  relationships: TermRelationships;
+}
+
+interface TermAttributes extends AttributesBase {
+  name: Nullable<string>;
+  /**
+   * A description of the type of this term (i.e., is it a protologism? A nonce?)
+   */
+  term_type: Nullable<string>;
+  definitions: string[];
+  definition_texs: string[];
+  sources: string[];
+  snippets: string[];
+}
+
+interface TermRelationships {
+  sentence: Relationship;
+  definition_sentences: Relationship[];
+  snippet_sentences: Relationship[];
+}
+
+interface SymbolRelationships {
+  equation: Relationship;
+  sentence: Relationship;
+  parent: Relationship;
+  children: Relationship[];
+  /**
+   * Experimental feature: link to the sentences that contain each type of definition. For each
+   * list of definitions in the symbol attributes (i.e., nicknames, definitions, defining
+   * formulas, etc.), there should be one relationship to a the sentence containing that definition.
+   * Therefore, each of these relationship lists should have the same length as the corresponding
+   * list of definitions in the attributes.
+   */
+  nickname_sentences: Relationship[];
+}
+
+export interface Equation extends EntityBase {
+  type: 'equation';
+  attributes: EquationAttributes;
+}
+
+interface EquationAttributes extends AttributesBase {
+  tex: Nullable<string>;
+}
+
+export interface Sentence extends EntityBase {
+  type: "sentence";
+  attributes: SentenceAttributes;
+}
+
+interface SentenceAttributes extends AttributesBase {
+  text: Nullable<string>;
+  tex: Nullable<string>;
+  tex_start: Nullable<number>;
+  tex_end: Nullable<number>;
+}
+
+interface SharedSymbolData {
+  defining_formula_equations: string[];  // entity id
+  defining_formulas: string[];  // tex-bearing formula text
+  definition_sentences: string[];
+  definition_texs: string[];
+  definitions: string[];
+  snippets: string[];  // tex-bearing sentence text
+  snippet_sentences: string[];  // entity id
+  sources: string[];
+}
+
+export function isCitation(entity: Entity): entity is Citation {
+  return entity.type === "citation";
+}
+
+export function isSymbol(entity: Entity): entity is Symbol {
+  return entity.type === "symbol";
+}
+
+export function isTerm(entity: Entity): entity is Term {
+  return entity.type === "term";
+}
+
+export function isEquation(entity: Entity): entity is Equation {
+  return entity.type === "equation";
+}
+
+export function isSentence(entity: Entity): entity is Sentence {
+  return entity.type === "sentence";
+}
+
+export function toLegacyRelationship(rel: Relationship, type: string): LegacyRelationship {
+  if (typeof rel === "string") {
+    return {
+      id: rel,
+      type
+    };
+  }
+  return {
+    id: rel.id,
+    type
+  };
+}

--- a/ui/src/api/deduped.ts
+++ b/ui/src/api/deduped.ts
@@ -52,7 +52,7 @@ interface SymbolAttributes extends AttributesBase {
   /**
    * This is the ID to use when getting SharedSymbolData for this entity.
    */
-  disambiguated_id: string;
+  disambiguated_id: Nullable<string>;
   /**
    * Nicknames for the symbol extracted from the text, no more than a few words long.
    */

--- a/ui/src/api/deduped.ts
+++ b/ui/src/api/deduped.ts
@@ -134,6 +134,9 @@ interface SharedSymbolData {
   sources: string[];
 }
 
+/*
+ * Type guards for handling specific types of entities.
+ */
 export function isCitation(entity: Entity): entity is Citation {
   return entity.type === "citation";
 }
@@ -154,6 +157,15 @@ export function isSentence(entity: Entity): entity is Sentence {
   return entity.type === "sentence";
 }
 
+/**
+ * We can express relationships more compactly as a list of IDs, but
+ * exisiting code expects each relationship entry to also define what
+ * entity type it links to, despite relationships always linking
+ * to one type of entity.
+ * @param rel The relationship to process
+ * @param type The entity type to which this relationship links
+ * @returns old-form {id, type} tuple describing the relationship
+ */
 export function toLegacyRelationship(rel: Relationship, type: string): LegacyRelationship {
   if (typeof rel === "string") {
     return {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -109,7 +109,7 @@ export interface BaseEntity {
  * All entities must define at least these attributes.
  */
 export interface BaseEntityAttributes {
-  version: number;
+  version?: number;
   source: string;
   bounding_boxes: BoundingBox[];
   /**
@@ -210,7 +210,7 @@ export interface Symbol extends BaseEntity {
 
 export interface SymbolAttributes extends BaseEntityAttributes {
   tex: string | null;
-  type: "identifier" | "function" | "operator";
+  type: "identifier" | "function" | "operator"; // TODO: This is null too with the deduped endpoint
   mathml: string | null;
   mathml_near_matches: string[];
   is_definition: boolean | null;
@@ -374,7 +374,7 @@ export function isSentence(entity: Entity): entity is Sentence {
  * coordinates when processing PDFs and PostScript files with Python.
  */
 export interface BoundingBox {
-  source: string;
+  source?: string;
   /**
    * Page indexes start at 0.
    */


### PR DESCRIPTION
This change adds an API handler for the new `entities-deduped` endpoint and a glorious un-dedupe function to make its response compatible with the existing code. Not an efficient use of memory within the browser, but it at least allows us to get the perf benefit of the new API without having to change all the UI component code.

Because `entities-deduped` is a much faster API for returning the full set of entity data, I also removed the `&showAll=true` URL param from the reader and made it always request the full set.

A couple related notes:
- With the slimmer API responses, the entities don't include their version numbers (since we only query one version at a time and these are always the same value) or sources (like 97% of these are `tex-pipeline` with a small remainder of `human-annotator`)
- `tags` also were generally empty and so don't get returned, but this change can be undone because I recently realized that tags were added as means of filtering out entities with weird bounding boxes.

I've done some ad-hoc testing to verify that it works for the paper `https://arxiv.org/pdf/1601.00978v1.pdf` but we should test some other papers with symbol content to increase confidence.