### PR TITLE
validate math arxiv IDs

### DIFF
--- a/api/src/types/validation.test.ts
+++ b/api/src/types/validation.test.ts
@@ -1,0 +1,46 @@
+import { paperSelector } from './validation';
+
+describe('paperSelector', () => {
+  it('accepts valid S2 IDs', () => {
+    const selector = { paperSelector: '866d17b5f7984af4f6f8e65a79c093417ad3f011' };
+    const result = paperSelector.validate(selector);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('rejects invalid S2 IDs', () => {
+    const zSelector = { paperSelector: 'zzzzzzb5f7984af4f6f8e65a79c093417ad3f011' };
+    expect(paperSelector.validate(zSelector).error).toBeDefined();
+
+    const shortSelector = { paperSelector: 'b5f7984af4f6f8e65a79c093417ad3f011' };
+    expect(paperSelector.validate(shortSelector).error).toBeDefined();
+
+    const longSelector = { paperSelector: '866d17b5f7984af4f6f8e65a79c093417ad3f0111' };
+    expect(paperSelector.validate(longSelector).error).toBeDefined();
+  });
+
+  it('accepts new arXiv IDs', () => {
+    const selector = { paperSelector: 'arxiv:2010.08824v1' };
+    const result = paperSelector.validate(selector);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('accepts old arXiv IDs', () => {
+    const selector = { paperSelector: 'arxiv:astro-ph/0201002v1' };
+    const result = paperSelector.validate(selector);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('accepts old arXiv IDs with the optional bit', () => {
+    const selector = { paperSelector: 'arxiv:math.GT/0008020v2' };
+    const result = paperSelector.validate(selector);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('accepts arXiv IDs without versions', () => {
+    const newSelector = { paperSelector: 'arxiv:2010.08824' };
+    expect(paperSelector.validate(newSelector).error).toBeUndefined();
+
+    const oldSelector = { paperSelector: 'arxiv:astro-ph/0201002' };
+    expect(paperSelector.validate(oldSelector).error).toBeUndefined();
+  });
+});

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -24,6 +24,7 @@ const s2paperId = Joi.string().pattern(/[a-f0-9]{40}/);
  * https://arxiv.org/help/arxiv_identifier.
  */
 const currentArxivFormat = Joi.string().pattern(/arxiv:[0-9]{2}[0-9]{2}.[0-9]+(v[0-9]+)?/);
+const arxivMathFormat = Joi.string().pattern(/arxiv:math\/[0-9]{5,}(v[0-9]+)/);
 const olderArxivFormat = Joi.string().pattern(
   /arxiv:[a-zA-Z0-9-]+\.[A-Z]{2}\/[0-9]{2}[0-9]{2}[0-9]+(v[0-9]+)/
 );
@@ -32,6 +33,7 @@ export const paperSelector = Joi.object({
   paperSelector: Joi.alternatives().try(
     s2paperId,
     currentArxivFormat,
+    arxivMathFormat,
     olderArxivFormat,
   )
 });

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -18,22 +18,20 @@ export const logEntry = Joi.object({
   data: Joi.object().unknown(true).default(null),
 });
 
-const s2paperId = Joi.string().pattern(/[a-f0-9]{40}/);
+const s2paperId = Joi.string().pattern(/^[a-f0-9]{40}$/);
 /*
  * See the arXiv documentation on valid identifiers here:
  * https://arxiv.org/help/arxiv_identifier.
  */
-const currentArxivFormat = Joi.string().pattern(/arxiv:[0-9]{2}[0-9]{2}.[0-9]+(v[0-9]+)?/);
-const arxivMathFormat = Joi.string().pattern(/arxiv:math\/[0-9]{5,}(v[0-9]+)/);
+const currentArxivFormat = Joi.string().pattern(/^arxiv:[0-9]{2}[0-9]{2}.[0-9]+(v[0-9]+)?$/);
 const olderArxivFormat = Joi.string().pattern(
-  /arxiv:[a-zA-Z0-9-]+\.[A-Z]{2}\/[0-9]{2}[0-9]{2}[0-9]+(v[0-9]+)/
+  /^arxiv:[a-zA-Z0-9\-]+(\.[A-Z]{2})?\/[0-9]{2}[0-9]{2}[0-9]+(v[0-9]+)?$/
 );
 
 export const paperSelector = Joi.object({
   paperSelector: Joi.alternatives().try(
     s2paperId,
     currentArxivFormat,
-    arxivMathFormat,
     olderArxivFormat,
   )
 });


### PR DESCRIPTION
We have a paper with ID `math/0008020v2` in the system. Turns out, the API never had a regex to handle IDs like this. Fortunately, it also turns out that `hapi` is decoding the encoded slash for us (in the URL, this ID looks like `math%2F0008020v2` so it doesn't change the route), so we don't need to manually handle that.