### PR TITLE
Fixes around fetching citations

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -754,6 +754,8 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             {} as { [s2Id: string]: Paper }
           );
           this.setState({ papers, areCitationsLoading: false });
+        } else {
+          this.setState({ areCitationsLoading: false });
         }
 
         if (window.heap) {

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -49,11 +49,17 @@ export async function listPapers(offset: number = 0, size: number = 25) {
  */
 export async function getPapers(s2Ids: string[]) {
   const PAPER_REQUEST_BATCH_SIZE = 50;
-  var s2IdsBatch = [];
-  var promises = [];
+  let s2IdsBatch = [];
+  let promises = [];
+  let dedupedIds: string[] = [];
+  s2Ids.forEach(id => {
+    if (dedupedIds.indexOf(id) < 0) {
+      dedupedIds.push(id);
+    }
+  });
 
-  for (let i = 0; i < s2Ids.length; i += PAPER_REQUEST_BATCH_SIZE) {
-    s2IdsBatch.push(s2Ids.slice(i, i + PAPER_REQUEST_BATCH_SIZE));
+  for (let i = 0; i < dedupedIds.length; i += PAPER_REQUEST_BATCH_SIZE) {
+    s2IdsBatch.push(dedupedIds.slice(i, i + PAPER_REQUEST_BATCH_SIZE));
   }
 
   for (let i = 0; i < s2IdsBatch.length; i++) {


### PR DESCRIPTION
This PR addresses two issues:
1. The list of S2 paper SHAs we pass to the `getPapers` function is not deduplicated, as every instance of a paper citation is its own citation entity linking to the same SHA. The Reader API does dedupe the IDs it receives before fetching the papers from the public S2 API, but the many duplicate IDs emitted from the reader result in more requests to the Reader API being sent than are necessary.
2. If the paper has no citation entities, we never turn off the loading spinner for citations. Whoops.

As a concrete example for item 1, with the paper `https://arxiv.org/pdf/2104.01111v1.pdf`:
- Current prod code results in 8 requests to the Reader API's /papers endpoint
- This branch only makes 4 requests to the Reader API