### PR TITLE
Fix the paper API

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -128,13 +128,8 @@ export const plugin = {
         });
         const data = (await s2Api.getPapers(uniqueIds, config.s2.apiKey))
           .filter((paper) => paper !== undefined)
-          .map((paper) => paper as Paper)
-          .map((paper) => ({
-            id: paper.s2Id,
-            type: "paper",
-            attributes: paper,
-          }));
-        return { data };
+          .map((paper) => paper as Paper);
+        return data;
       },
       options: {
         validate: {

--- a/ui/README.md
+++ b/ui/README.md
@@ -67,12 +67,8 @@ By default the UI proxies API requests to the production
 API (https://s2-reader.apps.allenai.org). This makes it possible
 to run a self-standing version of the UI locally.
 
-To use a local version of the API, export the `PROXY` environment
-variable like so:
-
-```bash
-export PROXY='http://localhost:3000'
-```
+To use a local version of the API, start the API locally and then
+start the UI using `npm run start:local`.
 
 See the README in the `api/` sibling directory for more information
 about running it locally.

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint '**/*.{js,ts,tsx,json}' && echo '💫  Lint complete.'",
     "lint:fix": "eslint '**/*.{js,ts,tsx,json}' --fix && npx sort-package-json  && echo '🛠  Lint --fix complete'",
     "start": "webpack serve --hot --mode development",
+    "start:local": "webpack serve --hot --mode development --env PROXY=http://localhost:3000",
     "test": "jest"
   },
   "resolutions": {


### PR DESCRIPTION
The /papers endpoint in the reader API was adding a bunch of JSON that was being stripped out in the client. I accidentally clobbered the UI side of that with commit https://github.com/allenai/scholarphi/commit/81c0b8f40ad8fe092b45cd80f99289f162199942, which broke the display of citations in the overlays because the API response was not matching the expected shape. Of course, there were no JS errors because ScholarPhi in general returns `undefined` and happily carries on without logging anything, but that's another story.

My change here gets rid of the additional JSON in the response that was just being stripped out in the client, which gets citations working again.