### PR TITLE
Mjlangan/lazy citations

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -441,6 +441,16 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/address": {
@@ -479,6 +489,16 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "^8.3.1"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/bourne": {
@@ -493,6 +513,16 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/catbox": {
@@ -504,6 +534,16 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/joi": "16.x.x",
         "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/catbox-memory": {
@@ -513,6 +553,16 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/content": {
@@ -521,6 +571,16 @@
       "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
       "requires": {
         "@hapi/boom": "7.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/cryptiles": {
@@ -529,6 +589,16 @@
       "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
       "requires": {
         "@hapi/boom": "7.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/file": {
@@ -566,6 +636,14 @@
         "@hapi/topo": "3.x.x"
       },
       "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        },
         "@hapi/joi": {
           "version": "15.1.1",
           "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
@@ -587,6 +665,16 @@
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x",
         "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/hoek": {
@@ -604,6 +692,16 @@
         "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
         "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/joi": {
@@ -646,6 +744,16 @@
         "@hapi/content": "^4.1.1",
         "@hapi/hoek": "8.x.x",
         "@hapi/nigel": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/pinpoint": {
@@ -692,6 +800,16 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/iron": "5.x.x",
         "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/subtext": {
@@ -706,6 +824,16 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/pez": "^4.1.2",
         "@hapi/wreck": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/teamwork": {
@@ -737,6 +865,16 @@
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
         "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -1500,6 +1638,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@types/hapi-auth-bearer-token/-/hapi-auth-bearer-token-6.1.2.tgz",
       "integrity": "sha512-zwR3VBoVVHOZ/+lFe5QSgJkT/thJU+sjBFijMQGMkp4vk9ZD21/01AXyWwKw6h6YNBvPzGAlm/WvNhBDZxRqMw==",
+      "dev": true,
       "requires": {
         "@types/hapi__hapi": "*"
       }
@@ -1507,17 +1646,20 @@
     "@types/hapi__boom": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@types/hapi__boom/-/hapi__boom-7.4.1.tgz",
-      "integrity": "sha512-x/ZK824GomII7Yoei/nMoB46NQcSfGe0iVpZK3uUivxIAfUUSzRvu8RQO7ZkKapIgzgshHZc+GR+z/BQ8l2VLg=="
+      "integrity": "sha512-x/ZK824GomII7Yoei/nMoB46NQcSfGe0iVpZK3uUivxIAfUUSzRvu8RQO7ZkKapIgzgshHZc+GR+z/BQ8l2VLg==",
+      "dev": true
     },
     "@types/hapi__catbox": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.2.tgz",
-      "integrity": "sha512-AWK70LgRsRWL1TNw+aT0IlS56E0pobvFdr/en0K8XazyK4Ey6T/jXhQqv/iQ6FJAAU+somMzgmt9fWq2TaaOkA=="
+      "integrity": "sha512-AWK70LgRsRWL1TNw+aT0IlS56E0pobvFdr/en0K8XazyK4Ey6T/jXhQqv/iQ6FJAAU+somMzgmt9fWq2TaaOkA==",
+      "dev": true
     },
     "@types/hapi__hapi": {
       "version": "18.2.5",
       "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-18.2.5.tgz",
       "integrity": "sha512-hCAQVtE3OZCihJrn5SxQYmAkIdtE1BwAyvGkxwnPwP+IIe0MQxqbP2s0cwlAwimGOdDQ/ArH+7i6FGDKPlZhFQ==",
+      "dev": true,
       "requires": {
         "@types/hapi__boom": "*",
         "@types/hapi__catbox": "*",
@@ -1533,6 +1675,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__iron/-/hapi__iron-5.1.0.tgz",
       "integrity": "sha512-RxYHIc8wFe8M1jMwgovskoHNVjuP1q0tUGCNnbHnhA4SBMyYg+JHIAz8yFibSwgF4gWYh5yHMpbmK5kmnG4HRA==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1540,12 +1683,14 @@
     "@types/hapi__joi": {
       "version": "16.0.2",
       "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-16.0.2.tgz",
-      "integrity": "sha512-mBJ70SvfnlmeVNRiq34M0FwZ0xkFwwLN2eQkneT2DStDITKiWEV4ycE2Muq0PavBj+pc8wVtxpJwAR+YAMIplg=="
+      "integrity": "sha512-mBJ70SvfnlmeVNRiq34M0FwZ0xkFwwLN2eQkneT2DStDITKiWEV4ycE2Muq0PavBj+pc8wVtxpJwAR+YAMIplg==",
+      "dev": true
     },
     "@types/hapi__mimos": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.0.tgz",
       "integrity": "sha512-hcdSoYa32wcP+sEfyf85ieGwElwokcZ/mma8eyqQ4OTHeCAGwfaoiGxjG4z1Dm+RGhIYLHlW54ji5FFwahH12A==",
+      "dev": true,
       "requires": {
         "@types/mime-db": "*"
       }
@@ -1553,12 +1698,14 @@
     "@types/hapi__podium": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__podium/-/hapi__podium-3.4.0.tgz",
-      "integrity": "sha512-LE85jLgqR5HscGQ7SaSz6FMRsKlQ1wHVbYc9u0yq7NKDRvZiQFIrr3Pl1RPzK7QNUdZP8zmJibe8q0JcafTAJQ=="
+      "integrity": "sha512-LE85jLgqR5HscGQ7SaSz6FMRsKlQ1wHVbYc9u0yq7NKDRvZiQFIrr3Pl1RPzK7QNUdZP8zmJibe8q0JcafTAJQ==",
+      "dev": true
     },
     "@types/hapi__shot": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.0.tgz",
       "integrity": "sha512-vIySJYkwIGXMB5eFaZu3U8dS9CAZmteJfmkRn9bYH5uNcSvVgiwDROiwAkD7ej88qA+RZPkUK70KmeDs3LRHvw==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1712,7 +1859,8 @@
     "@types/mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I="
+      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
+      "dev": true
     },
     "@types/nconf": {
       "version": "0.10.0",
@@ -1723,7 +1871,8 @@
     "@types/node": {
       "version": "12.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
-      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA=="
+      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3205,6 +3354,21 @@
         "@hapi/joi": "^15.0.3"
       },
       "dependencies": {
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          },
+          "dependencies": {
+            "@hapi/hoek": {
+              "version": "8.5.1",
+              "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+              "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+            }
+          }
+        },
         "@hapi/hoek": {
           "version": "6.2.4",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
+    "@hapi/boom": "^7.4.11",
     "@hapi/hapi": "^18.4.1",
     "@hapi/joi": "^16.1.7",
     "@types/lru-cache": "^5.1.0",

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -15,8 +15,6 @@ import {
 } from "./types/api";
 import * as validation from "./types/validation";
 import * as conf from "./conf";
-import { AxiosError } from "axios";
-import { S2ApiError } from "./types/s2-api";
 
 interface ApiOptions {
   connection: Connection;
@@ -120,17 +118,18 @@ export const plugin = {
       path: "paper/{s2Id}",
       handler: async (request) => {
         const s2Id = request.params.s2Id;
-        const paper = await s2Api.getPaperUncached(s2Id, config.s2.apiKey)
-        .then(p => p.data)
-        .catch((error: AxiosError<S2ApiError>) => {
+        let resp = null;
+        try {
+          resp = await s2Api.getPaperUncached(s2Id, config.s2.apiKey);
+        } catch (error) {
           if (error.response?.status === 404) {
             throw Boom.notFound(`not found: ${s2Id}`);
           } else if (error.response?.status === 500) {
             throw Boom.internal(`S2 API Error accessing paper ${s2Id}`);
           }
           throw Boom.internal(`Internal Error: ${error}`);
-        });
-        return paper;
+        }
+        return resp?.data;
       },
       options: {
         validate: {

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -1,3 +1,4 @@
+import * as Boom from "@hapi/boom";
 import * as Hapi from "@hapi/hapi";
 import * as HapiAuthBearer from 'hapi-auth-bearer-token';
 import * as Joi from "@hapi/joi";
@@ -14,6 +15,8 @@ import {
 } from "./types/api";
 import * as validation from "./types/validation";
 import * as conf from "./conf";
+import { AxiosError } from "axios";
+import { S2ApiError } from "./types/s2-api";
 
 interface ApiOptions {
   connection: Connection;
@@ -110,6 +113,32 @@ export const plugin = {
         const response: Paginated<PaperWithIdInfo> = { ...papers, ...{ rows: mergedPapers } };
         return response;
       },
+    });
+
+    server.route({
+      method: "GET",
+      path: "paper/{s2Id}",
+      handler: async (request) => {
+        const s2Id = request.params.s2Id;
+        const paper = await s2Api.getPaperUncached(s2Id, config.s2.apiKey)
+        .then(p => p.data)
+        .catch((error: AxiosError<S2ApiError>) => {
+          if (error.response?.status === 404) {
+            throw Boom.notFound(`not found: ${s2Id}`);
+          } else if (error.response?.status === 500) {
+            throw Boom.internal(`S2 API Error accessing paper ${s2Id}`);
+          }
+          throw Boom.internal(`Internal Error: ${error}`);
+        });
+        return paper;
+      },
+      options: {
+        validate: {
+          params: Joi.object({
+            s2Id: validation.s2paperId
+          })
+        }
+      }
     });
 
     server.route({

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -118,18 +118,19 @@ export const plugin = {
       path: "paper/{s2Id}",
       handler: async (request) => {
         const s2Id = request.params.s2Id;
-        let resp = null;
         try {
-          resp = await s2Api.getPaperUncached(s2Id, config.s2.apiKey);
+          const resp = await s2Api.getPaperUncached(s2Id, config.s2.apiKey);
+          return resp.data;
         } catch (error) {
-          if (error.response?.status === 404) {
-            throw Boom.notFound(`not found: ${s2Id}`);
-          } else if (error.response?.status === 500) {
-            throw Boom.internal(`S2 API Error accessing paper ${s2Id}`);
+          switch(error.response?.status) {
+            case 404:
+              throw Boom.notFound(`not found: ${s2Id}`);
+            case 500:
+              throw Boom.internal(`S2 API Error accessing paper ${s2Id}`);
+            default:
+              throw Boom.internal(`Internal Error: ${error}`);
           }
-          throw Boom.internal(`Internal Error: ${error}`);
         }
-        return resp?.data;
       },
       options: {
         validate: {

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -66,37 +66,14 @@ async function getPaper(s2Id: string, apiKey?: string): Promise<Paper | undefine
     return Promise.resolve(cached);
   }
 
-  if (!apiKey) {
-    console.warn(`
-      WARNING: The S2 Public API Key isn't set. If the backend makes more than 100 requests to
-      the public API in 5 minutes it'll be rate limited and might stop working.
-
-      See the README.md for more information about geting an API key.
-    `);
-  }
-
-  const conf: AxiosRequestConfig = {
-    headers: {
-      'user-agent': 'Semantic Reader API Client (https://scholarphi.semanticscholar.org)'
-    }
-  };
-  if (apiKey) {
-    conf.headers['x-api-key'] = apiKey;
-  }
-  const apiOrigin = (
-    apiKey
-      ? "https://partner.semanticscholar.org/v1"
-      : "https://api.semanticscholar.org/v1"
-  );
-  const response = await axios.get<S2ApiPaper>(`${apiOrigin}/paper/${s2Id}`, conf);
-  const paper = toPaper(s2Id, response.data);
-  // only cache if the request is successful to avoid papers being permanent errors
-  if (response.status === 200) {
+  try {
+    const resp = await getPaperUncached(s2Id, apiKey);
+    const paper = resp.data;
     cache.set(s2Id, paper);
+    return paper;
+  } catch (err) {
+    throw err;
   }
-
-
-  return paper;
 }
 
 /**

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -1,7 +1,7 @@
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse, AxiosTransformer } from "axios";
 import * as LRU from 'lru-cache';
-import { Paper } from "./types/api";
-import { S2ApiPaper } from "./types/s2-api";
+import { Paper, Nullable } from "./types/api";
+import { isS2ApiError, S2ApiError, S2ApiPaper } from "./types/s2-api";
 
 /**
  * We cache the papers returned from S2's API, since the data doesn't change often and it
@@ -90,7 +90,69 @@ async function getPaper(s2Id: string, apiKey?: string): Promise<Paper | undefine
   );
   const response = await axios.get<S2ApiPaper>(`${apiOrigin}/paper/${s2Id}`, conf);
   const paper = toPaper(s2Id, response.data);
-  cache.set(s2Id, paper);
+  // only cache if the request is successful to avoid papers being permanent errors
+  if (response.status === 200) {
+    cache.set(s2Id, paper);
+  }
+
 
   return paper;
+}
+
+/**
+ * Fetches a single paper from the S2 API and converts it into a Paper,
+ * while also allowing for error handling using axios's promise interface.
+ *
+ * @param s2Id SHA of the paper to request
+ * @param apiKey optional key for higher rate limit
+ * @returns
+ */
+export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Paper> {
+  if (!apiKey) {
+    console.warn(`
+      WARNING: The S2 Public API Key isn't set. If the backend makes more than 100 requests to
+      the public API in 5 minutes it'll be rate limited and might stop working.
+
+      See the README.md for more information about geting an API key.
+    `);
+  }
+
+  const conf: AxiosRequestConfig = {
+    headers: {
+      "user-agent":
+        "Semantic Reader API Client (https://scholarphi.semanticscholar.org)",
+    },
+    // cast to AxiosTransformer[] or else the base type is never[]
+    // TODO: See if a newer version of typescript is better at resolving empty array types
+    transformResponse: ([] as AxiosTransformer[])
+    // axios defaults must come first or the transform function underneath gets the raw string
+    // because the defaults use the same interface as the config, TS thinks this is optional on the defaults.
+    .concat(axios.defaults.transformResponse || [])
+    .concat(
+      (data: S2ApiPaper | S2ApiError): Nullable<Paper> => {
+        if (isS2ApiError(data)) {
+          // API error gets handled by catching the promise
+          return null;
+        }
+        return toPaper(s2Id, data);
+      }
+    ),
+  };
+  if (apiKey) {
+    conf.headers['x-api-key'] = apiKey;
+  }
+  const apiOrigin = (
+    apiKey
+      ? "https://partner.semanticscholar.org/v1"
+      : "https://api.semanticscholar.org/v1"
+  );
+
+  return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf)
+  .then((resp) => {
+    // Side effect promise to cache the result if successful
+    if (resp.status === 200) {
+      cache.set(s2Id, resp.data);
+    }
+    return resp;
+  });
 }

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -147,12 +147,5 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
       : "https://api.semanticscholar.org/v1"
   );
 
-  return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf)
-  .then((resp) => {
-    // Side effect promise to cache the result if successful
-    if (resp.status === 200) {
-      cache.set(s2Id, resp.data);
-    }
-    return resp;
-  });
+  return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }

--- a/api/src/types/api.ts
+++ b/api/src/types/api.ts
@@ -12,6 +12,8 @@
  * into other projects, all of the types are available to the client code.
  */
 
+export type Nullable<T> = T | null;
+
 export interface Paginated<T> {
   rows: T[];
   offset: number;

--- a/api/src/types/s2-api.ts
+++ b/api/src/types/s2-api.ts
@@ -17,3 +17,11 @@ interface S2ApiAuthor {
   name: string;
   url: string;
 }
+
+export interface S2ApiError {
+  error: string;
+}
+
+export function isS2ApiError(d: any): d is S2ApiError {
+  return !!d.error && typeof d.error === "string";
+}

--- a/api/src/types/validation.ts
+++ b/api/src/types/validation.ts
@@ -18,7 +18,7 @@ export const logEntry = Joi.object({
   data: Joi.object().unknown(true).default(null),
 });
 
-const s2paperId = Joi.string().pattern(/^[a-f0-9]{40}$/);
+export const s2paperId = Joi.string().pattern(/^[a-f0-9]{40}$/);
 /*
  * See the arXiv documentation on valid identifiers here:
  * https://arxiv.org/help/arxiv_identifier.

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -82,6 +82,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
 
     this.state = {
       entities: null,
+      lazyPapers: new Map(),
 
       userLibrary: null,
 
@@ -755,6 +756,14 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
     }
   }
 
+  cachePaper = (paper: Paper, cb?: () => void): void => {
+    const paperMap = new Map(this.state.lazyPapers);
+    paperMap.set(paper.s2Id, paper);
+    this.setState({
+      lazyPapers: paperMap,
+    }, cb);
+  }
+
   jumpToEntityWithBackMessage = (id: string): void => {
     const success = this.jumpToEntity(id);
 
@@ -1116,6 +1125,8 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                         paperId={this.props.paperId}
                         pageView={pageView}
                         entities={entities}
+                        lazyPapers={this.state.lazyPapers}
+                        cachePaper={this.cachePaper}
                         userLibrary={this.state.userLibrary}
                         selectedEntityIds={selectedEntityIds}
                         selectedAnnotationIds={selectedAnnotationIds}

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -58,7 +58,6 @@ import * as uiUtils from "./utils/ui";
 import ViewerOverlay from "./components/overlay/ViewerOverlay";
 
 import classNames from "classnames";
-import queryString from "query-string";
 import React from "react";
 
 interface Props {
@@ -83,7 +82,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
 
     this.state = {
       entities: null,
-      papers: null,
 
       userLibrary: null,
 
@@ -730,9 +728,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
 
   loadDataFromApi = async (): Promise<void> => {
     if (this.props.paperId !== undefined && this.props.paperId.type === "arxiv") {
-      this.setState({
-        areCitationsLoading: true
-      });
       const loadingStartTime = performance.now();
       const entities = await api.getDedupedEntities(this.props.paperId.id, true);
       this.setState({
@@ -744,18 +739,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
         .map((c) => c.attributes.paper_id)
         .filter((id) => id !== null)
         .map((id) => id as string);
-      if (citationS2Ids.length >= 1) {
-        const papers = (await api.getPapers(citationS2Ids)).reduce(
-          (papers, paper) => {
-            papers[paper.s2Id] = paper;
-            return papers;
-          },
-          {} as { [s2Id: string]: Paper }
-        );
-        this.setState({ papers, areCitationsLoading: false });
-      } else {
-        this.setState({ areCitationsLoading: false });
-      }
 
       if (window.heap) {
         const loadingTimeMS = Math.round(performance.now() - loadingStartTime);
@@ -1132,7 +1115,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                       <EntityAnnotationLayer
                         paperId={this.props.paperId}
                         pageView={pageView}
-                        papers={this.state.papers}
                         entities={entities}
                         userLibrary={this.state.userLibrary}
                         selectedEntityIds={selectedEntityIds}

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -28,6 +28,7 @@ import {
   isTerm,
   toLegacyRelationship
 } from "./deduped";
+import { Nullable } from "../types/ui";
 
 const token = cookie.parse(document.cookie)["readerAdminToken"];
 
@@ -88,6 +89,13 @@ export async function getEntities(arxivId: string, getAllEntities?: boolean) {
     axios.get(`/api/v0/papers/arxiv:${encodeURIComponent(arxivId)}/entities`, { params })
   );
   return ((data as any).data || []) as Entity[];
+}
+
+export async function getPaper(s2Id: string): Promise<Nullable<Paper>> {
+  const data = await doGet(
+    axios.get<Paper>(`/api/v0/paper/${encodeURIComponent(s2Id)}`, {
+    }));
+  return data;
 }
 
 // This translates from the entities-deduped API's response to the legacy

--- a/ui/src/api/deduped.ts
+++ b/ui/src/api/deduped.ts
@@ -1,6 +1,5 @@
 import { BoundingBox, Relationship as LegacyRelationship } from './types';
-
-export type Nullable<T> = T | null;
+import { Nullable } from '../types/ui';
 
 /**
  * Types defined in here are for the entities-deduped endpoint,

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -10,11 +10,11 @@ import {
 } from "../../api/types";
 import * as selectors from "../../selectors";
 import { GlossStyle } from "../../settings";
-import { Entities, PaperId, Papers, UserLibrary } from "../../state";
+import { Entities, PaperId, UserLibrary } from "../../state";
 import { PDFPageView } from "../../types/pdfjs-viewer";
 import * as uiUtils from "../../utils/ui";
 import { DrawerContentType } from "../drawer/Drawer";
-import CitationGloss from "../entity/citation/CitationGloss";
+import LazyCitationGloss from "./citation/LazyCitationGloss";
 import EntityAnnotation from "./EntityAnnotation";
 import SimpleSymbolGloss from "./SimpleSymbolGloss";
 import SimpleTermGloss from "./SimpleTermGloss";
@@ -24,7 +24,6 @@ export type SymbolUnderlineMethod = "top-level-symbols" | "defined-symbols";
 interface Props {
   paperId?: PaperId;
   pageView: PDFPageView;
-  papers: Papers | null;
   entities: Entities;
   userLibrary: UserLibrary | null;
   selectedEntityIds: string[];
@@ -155,7 +154,6 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
     const {
       paperId,
       pageView,
-      papers,
       entities,
       userLibrary,
       selectedEntityIds,
@@ -268,9 +266,7 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
           } else if (
             citationAnnotationsEnabled &&
             isCitation(entity) &&
-            papers !== null &&
-            entity.attributes.paper_id !== null &&
-            papers[entity.attributes.paper_id] !== undefined
+            entity.attributes.paper_id !== null
           ) {
             return (
               <EntityAnnotation
@@ -283,9 +279,8 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
                 glossStyle={glossStyle}
                 glossContent={
                   showGlosses ? (
-                    <CitationGloss
+                    <LazyCitationGloss
                       citation={entity}
-                      paper={papers[entity.attributes.paper_id]}
                       userLibrary={userLibrary}
                       handleAddPaperToLibrary={handleAddPaperToLibrary}
                       openedPaperId={paperId}

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -7,6 +7,7 @@ import {
   isSentence,
   isSymbol,
   isTerm,
+  Paper,
 } from "../../api/types";
 import * as selectors from "../../selectors";
 import { GlossStyle } from "../../settings";
@@ -25,6 +26,7 @@ interface Props {
   paperId?: PaperId;
   pageView: PDFPageView;
   entities: Entities;
+  lazyPapers: Map<string, Paper>;
   userLibrary: UserLibrary | null;
   selectedEntityIds: string[];
   selectedAnnotationIds: string[];
@@ -51,6 +53,7 @@ interface Props {
   handleAddPaperToLibrary: (paperId: string, paperTitle: string) => void;
   handleJumpToEntity: (entityId: string) => void;
   handleOpenDrawer: (contentType: DrawerContentType) => void;
+  cachePaper: (paper: Paper) => void;
 }
 
 class EntityAnnotationLayer extends React.Component<Props, {}> {
@@ -155,6 +158,8 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
       paperId,
       pageView,
       entities,
+      lazyPapers,
+      cachePaper,
       userLibrary,
       selectedEntityIds,
       selectedAnnotationIds,
@@ -281,10 +286,12 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
                   showGlosses ? (
                     <LazyCitationGloss
                       citation={entity}
+                      lazyPapers={lazyPapers}
                       userLibrary={userLibrary}
                       handleAddPaperToLibrary={handleAddPaperToLibrary}
                       openedPaperId={paperId}
                       evaluationEnabled={glossEvaluationEnabled}
+                      cachePaper={cachePaper}
                     />
                   ) : null
                 }

--- a/ui/src/components/entity/citation/LazyCitationGloss.tsx
+++ b/ui/src/components/entity/citation/LazyCitationGloss.tsx
@@ -39,7 +39,7 @@ export default class LazyCitationGloss extends React.PureComponent<Props, State>
         });
       }).catch((err: AxiosError /* Fairly sure this is the type, though AxiosPromise gets abstracted away */) => {
         this.setState({
-          error: err ? err.message : 'Could not load paper data',
+          error: err?.message ? err.message : 'Could not load paper data',
         });
       });
     } else {
@@ -66,7 +66,7 @@ export default class LazyCitationGloss extends React.PureComponent<Props, State>
         {this.state.error}
       </div>
     );
-    
+
     // @ts-ignore why is this resolving to null?!
     const paper: Paper = this.state.paper;
     const paperComponent = !!paper ? (

--- a/ui/src/components/entity/citation/LazyCitationGloss.tsx
+++ b/ui/src/components/entity/citation/LazyCitationGloss.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import PaperSummary from "./PaperSummary";
+import { PaperId, UserLibrary } from "../../../state";
+import { Citation, Paper } from "../../../api/types";
+import { VoteButton } from "../../common";
+import { Nullable } from '../../../types/ui';
+import { getPaper } from '../../../api/api';
+import { LinearProgress } from "@material-ui/core";
+import { AxiosError } from "axios";
+
+interface Props {
+  citation: Citation;
+  evaluationEnabled?: boolean;
+  handleAddPaperToLibrary: (paperId: string, paperTitle: string) => void;
+  openedPaperId?: PaperId;
+  userLibrary: Nullable<UserLibrary>;
+}
+
+interface State {
+  error: Nullable<string>;
+  isLoadingPaper: boolean;
+  paper: Nullable<Paper>;
+}
+
+export default class LazyCitationGloss extends React.PureComponent<Props, State> {
+  state = {
+    error: null,
+    isLoadingPaper: false,
+    paper: null,
+  };
+
+  componentDidMount() {
+    if (!!this.props.citation.attributes.paper_id) {
+      this.setState({ isLoadingPaper: true });
+      getPaper(this.props.citation.attributes.paper_id).then(paper => {
+        this.setState({
+          paper,
+          isLoadingPaper: false,
+        });
+      }).catch((err: AxiosError /* Fairly sure this is the type, though AxiosPromise gets abstracted away */) => {
+        this.setState({
+          error: err ? err.message : 'Could not load paper data',
+        });
+      });
+    } else {
+      this.setState({
+        error: 'No paper data available',
+      });
+    }
+  }
+
+  render() {
+    const { isLoadingPaper } = this.state;
+    const noPaperComponent = isLoadingPaper ? (
+      <div className="paper-summary">
+        <div className="paper-summary__loading-msg">
+          Loading...
+        </div>
+        <LinearProgress/>
+      </div>
+    ) : (
+      <div className="paper-summary">
+        <div className="paper-summary__loading-msg">
+          Error
+        </div>
+        {this.state.error}
+      </div>
+    );
+    
+    // @ts-ignore why is this resolving to null?!
+    const paper: Paper = this.state.paper;
+    const paperComponent = !!paper ? (
+      <PaperSummary
+            paper={paper}
+            userLibrary={this.props.userLibrary}
+            handleAddPaperToLibrary={this.props.handleAddPaperToLibrary}
+            openedPaperId={this.props.openedPaperId}
+          />
+    ) : noPaperComponent;
+
+    return (
+      <div className="gloss citation-gloss">
+        <div className="gloss__section">
+          {paperComponent}
+        </div>
+        {this.props.evaluationEnabled ? (
+          <div className="citation-gloss__vote-button">
+            <VoteButton
+              context={{
+                citation: this.props.citation,
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+}

--- a/ui/src/components/entity/citation/LazyCitationGloss.tsx
+++ b/ui/src/components/entity/citation/LazyCitationGloss.tsx
@@ -40,6 +40,7 @@ export default class LazyCitationGloss extends React.PureComponent<Props, State>
       }).catch((err: AxiosError /* Fairly sure this is the type, though AxiosPromise gets abstracted away */) => {
         this.setState({
           error: err?.message ? err.message : 'Could not load paper data',
+          isLoadingPaper: false,
         });
       });
     } else {

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -45,7 +45,6 @@ export interface State extends Settings {
    * *** PAPER DATA ***
    */
   entities: Readonly<Entities> | null;
-  papers: Readonly<Papers> | null;
 
   /*
    * *** USER LIBRARY DATA ***

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -45,6 +45,7 @@ export interface State extends Settings {
    * *** PAPER DATA ***
    */
   entities: Readonly<Entities> | null;
+  lazyPapers: Map<string, Paper>;
 
   /*
    * *** USER LIBRARY DATA ***

--- a/ui/src/style/paper-summary.less
+++ b/ui/src/style/paper-summary.less
@@ -7,6 +7,10 @@
   color: @s2-text-default;
 }
 
+.paper-summary__loading-msg {
+  margin-bottom: 1em;
+}
+
 /**
  * Pad paper summary title so the favorite button doesn't occlude it
  */

--- a/ui/src/types/ui.ts
+++ b/ui/src/types/ui.ts
@@ -9,3 +9,5 @@ export interface Rectangle {
   width: number;
   height: number;
 }
+
+export type Nullable<T> = T | null;


### PR DESCRIPTION
`LazyCitationGloss` is essentially a copy-paste of `CitationGloss` but with added code to load the paper data on-demand, so it still has the library and feature voting buttons.

**GET /paper/{s2id}**
I wanted to try implementing an endpoint using `hapi` with error handling, which required bringing in the `@hapi/boom` library. Per the docs, `Boom.internal` exceptions don't return the message in the API response, but they do record it in the server logs. Unfortunately, using `AxiosPromise` as the return type, since this makes it easier for me to work with their errors, means I can't re-use the same paper cache in the current API layer. Since lazy-loading should result in way less requests to the S2 public API (now we're only requesting paper data for a paper when someone clicks it, vs. requesting all papers' data at load time), I think this is an acceptable trade-off, and we can always add it back in if performance or request load become an issue.

![](http://g.recordit.co/t24YJoi3hg.gif)