### PR TITLE
Use arxiv's compiler

### DIFF
--- a/data-processing/.dockerignore
+++ b/data-processing/.dockerignore
@@ -4,3 +4,4 @@ node/node_modules
 .vscode
 venv
 cache
+data

--- a/data-processing/.dockerignore
+++ b/data-processing/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 node/node_modules
 .vscode
 venv
+cache

--- a/data-processing/Dockerfile
+++ b/data-processing/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get install -y wget
 RUN wget https://arxiv-web-static1.s3.amazonaws.com/semantic_scholar_20210412/arXivTeXLive2020.tar.gz
 RUN tar -xf arXivTeXLive2020.tar.gz
 RUN echo "I" | perl 2020/install-tl
+RUN rm -r arXivTeXLive2020.tar.gz 2020
 
 # Install Perl dependencies
 SHELL ["/bin/bash", "-c"]

--- a/data-processing/Dockerfile
+++ b/data-processing/Dockerfile
@@ -53,10 +53,6 @@ RUN sed -i '/pattern="PDF"/s/rights="none"/rights="read | write"/' /etc/ImageMag
 # Install GhostScript
 RUN apt-get install -y ghostscript
 
-# Install pip requireements
-COPY requirements.txt ./
-RUN pip install -r requirements.txt
-
 # Install Node.js dependencies
 WORKDIR /data-processing/node
 RUN apt-get install -y git
@@ -69,6 +65,10 @@ RUN npm run install-katex
 
 # Install vim for when we inevitably want to inspect files
 RUN apt-get install -y vim
+
+# Install pip requireements
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
 
 # Copy over the source code
 WORKDIR /data-processing

--- a/data-processing/Dockerfile
+++ b/data-processing/Dockerfile
@@ -45,11 +45,6 @@ RUN python get-pip.py --force-reinstall
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
 RUN apt-get install -y nodejs
 
-# Let ImageMagick to read and write PDFs
-RUN apt-get install -y imagemagick imagemagick-6-common imagemagick-6.q16 \
-  libmagick++-6.q16-7 libmagickcore-6.q16-3 libmagickcore-6.q16-3-extra libmagickwand-6.q16-3
-RUN sed -i '/pattern="PDF"/s/rights="none"/rights="read | write"/' /etc/ImageMagick-6/policy.xml
-
 # Install GhostScript
 RUN apt-get install -y ghostscript
 
@@ -58,7 +53,7 @@ WORKDIR /data-processing/node
 RUN apt-get install -y git
 COPY node/package*.json ./
 RUN npm install
-# As KaTeX is undegoing rapid changes, install it from sources
+# As KaTeX is undergoing rapid changes, install it from sources
 RUN npm install -g yarn
 RUN npm run prepare-katex
 RUN npm run install-katex

--- a/data-processing/Dockerfile
+++ b/data-processing/Dockerfile
@@ -45,6 +45,11 @@ RUN python get-pip.py --force-reinstall
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
 RUN apt-get install -y nodejs
 
+# Let ImageMagick to read and write PDFs
+RUN apt-get install -y imagemagick imagemagick-6-common imagemagick-6.q16 \
+  libmagick++-6.q16-7 libmagickcore-6.q16-3 libmagickcore-6.q16-3-extra libmagickwand-6.q16-3
+RUN sed -i '/pattern="PDF"/s/rights="none"/rights="read | write"/' /etc/ImageMagick-6/policy.xml
+
 # Install GhostScript
 RUN apt-get install -y ghostscript
 
@@ -53,7 +58,7 @@ WORKDIR /data-processing/node
 RUN apt-get install -y git
 COPY node/package*.json ./
 RUN npm install
-# As KaTeX is undergoing rapid changes, install it from sources
+# As KaTeX is undegoing rapid changes, install it from sources
 RUN npm install -g yarn
 RUN npm run prepare-katex
 RUN npm run install-katex

--- a/data-processing/Dockerfile
+++ b/data-processing/Dockerfile
@@ -2,11 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update
 
-# Install LaTeX suite
-# This download will take an extremely long time to install, so we install it first
 # Set DEBIAN_FRONTEND to disable tzdatainteractive dialogue
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -y texlive-full
 
 # Install Perl
 # Build-essential is required for installing Perl dependencies
@@ -19,6 +16,19 @@ RUN cpan App::perlbrew
 RUN perlbrew init
 RUN perlbrew --notest install perl-5.22.4
 RUN perlbrew install-cpanm
+
+# Install LaTeX suite
+# This download will take an extremely long time to install, so we install it first
+RUN apt-get install -y wget
+RUN wget https://arxiv-web-static1.s3.amazonaws.com/semantic_scholar_20210412/arXivTeXLive2020.tar.gz
+RUN tar -xf arXivTeXLive2020.tar.gz
+RUN echo "I" | perl 2020/install-tl
+
+# Install Perl dependencies
+SHELL ["/bin/bash", "-c"]
+RUN source ~/perl5/perlbrew/etc/bashrc \
+  && perlbrew use perl-5.22.4 \
+  && cpanm TeX::AutoTeX
 
 # Install Postgres
 RUN apt-get install -y postgresql
@@ -36,6 +46,8 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
 RUN apt-get install -y nodejs
 
 # Let ImageMagick to read and write PDFs
+RUN apt-get install -y imagemagick imagemagick-6-common imagemagick-6.q16 \
+  libmagick++-6.q16-7 libmagickcore-6.q16-3 libmagickcore-6.q16-3-extra libmagickwand-6.q16-3
 RUN sed -i '/pattern="PDF"/s/rights="none"/rights="read | write"/' /etc/ImageMagick-6/policy.xml
 
 # Install GhostScript
@@ -44,12 +56,6 @@ RUN apt-get install -y ghostscript
 # Install pip requireements
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
-
-# Install Perl dependencies
-SHELL ["/bin/bash", "-c"]
-RUN source ~/perl5/perlbrew/etc/bashrc \
-  && perlbrew use perl-5.22.4 \
-  && cpanm TeX::AutoTeX
 
 # Install Node.js dependencies
 WORKDIR /data-processing/node

--- a/data-processing/config.ini
+++ b/data-processing/config.ini
@@ -9,12 +9,12 @@
 # (e.g., using a utility like 'locate' on OSX).
 [tex]
 # This directory should contain a 'texmf-dist' subdirectory.
-texlive_path = /usr/share/texlive/
+texlive_path = /usr/local/texlive/2020/
 # This is the directory that contains the 'pdflatex' and 'latex' binaries.
 # It should also contain binaries for typical sytem utilities like 'mkdir' and 'sed'
 # in case LaTeX needs to call them on the fly during compilation, as is the case for
 # on-demand font generation with 'kpathsea'.
-texlive_bin_path = /usr/bin/:/bin
+texlive_bin_path = /usr/local/texlive/2020/bin/x86_64-linux/:/usr/bin/:/bin
 
 # Commands for rastering TeX output files into images.
 # Each key is the extension for a type of TeX output (e.g., 'pdf', 'ps').

--- a/data-processing/requirements.txt
+++ b/data-processing/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.8.0
 lxml==4.4.2
 nltk==3.4.5
 numpy==1.17.4
-opencv-python==3.4.8.29
+opencv-python-headless==3.4.8.29
 # Sometime between versions 3.12.0 and 3.13.3, a change was made that influences how batch
 # inserts are made that breaks the function for uploading entities. 3.12.0 lets the code
 # create all entities, then bounding box models that refer to those entities, before


### PR DESCRIPTION
https://github.com/allenai/scholar/issues/27321

Changes:
1. Use TeXLive from Arxiv instead of from `apt-get`.
2. Change config.ini to point to where TeXLive is installed

Testing: manual testing
- can compile 2 latex files that were previously failed to compile
- can compile 1 latex file that was successfully compiled

Also, the image size balloons to 18GB. We're gonna need a bigger boat, @ca16.