### PR TITLE
Add warning if references exist, but can't match any with S2 reference data

### DIFF
--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -97,7 +97,7 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
         if item.bibitems and ref_match_count == 0:
             logging.warning(f"Could not match any reference for paper {item.arxiv_id}.")
         else:
-            logging.debug(f"Matched {ref_match_count} references for paper {item.arxiv_id}.")
+            logging.info(f"Matched {ref_match_count} references for paper {item.arxiv_id}.")
 
     def save(self, item: MatchTask, result: BibitemMatch) -> None:
         resolutions_dir = directories.arxiv_subdir("bibitem-resolutions", item.arxiv_id)

--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -70,7 +70,7 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
             yield MatchTask(arxiv_id, bibitems, references)
 
     def process(self, item: MatchTask) -> Iterator[BibitemMatch]:
-        count = 0
+        ref_match_count = 0
         for bibitem in item.bibitems:
             max_similarity = 0.0
             most_similar_reference = None
@@ -81,7 +81,7 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     most_similar_reference = reference
 
             if most_similar_reference is not None:
-                count += 1
+                ref_match_count += 1
                 yield BibitemMatch(
                     bibitem.id_,
                     bibitem.text,
@@ -94,8 +94,10 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     bibitem.id_,
                     item.arxiv_id,
                 )
-        if item.bibitems and count == 0:
+        if item.bibitems and ref_match_count == 0:
             logging.warning(f"Could not match any reference for paper {item.arxiv_id}.")
+        else:
+            logging.debug(f"Matched {ref_match_count} references for paper {item.arxiv_id}.")
 
     def save(self, item: MatchTask, result: BibitemMatch) -> None:
         resolutions_dir = directories.arxiv_subdir("bibitem-resolutions", item.arxiv_id)

--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -94,10 +94,21 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     bibitem.id_,
                     item.arxiv_id,
                 )
-        if item.bibitems and ref_match_count == 0:
-            logging.warning(f"Could not match any reference for paper {item.arxiv_id}.")
+
+        if item.bibitems:
+            if ref_match_count == 0:
+                logging.warning(
+                    f"Paper has reference(s), but could not match any to S2 reference data. Paper ID {item.arxiv_id}."
+                )
+            else:
+                logging.info(
+                    f"Paper has {len(item.bibitems)} references, " +
+                    f"able to match {ref_match_count} reference(s) to S2 data."
+                )
         else:
-            logging.info(f"Matched {ref_match_count} references for paper {item.arxiv_id}.")
+            logging.warning(
+                f"Could not extract any reference for paper {item.arxiv_id}."
+            )
 
     def save(self, item: MatchTask, result: BibitemMatch) -> None:
         resolutions_dir = directories.arxiv_subdir("bibitem-resolutions", item.arxiv_id)

--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -52,7 +52,7 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     references_path,
                     arxiv_id,
                 )
-                return
+                continue
             references = list(
                 file_utils.load_from_csv(references_path, SerializableReference)
             )
@@ -64,12 +64,13 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     bibitems_path,
                     arxiv_id,
                 )
-                return
+                continue
             bibitems = list(file_utils.load_from_csv(bibitems_path, Bibitem))
 
             yield MatchTask(arxiv_id, bibitems, references)
 
     def process(self, item: MatchTask) -> Iterator[BibitemMatch]:
+        count = 0
         for bibitem in item.bibitems:
             max_similarity = 0.0
             most_similar_reference = None
@@ -80,6 +81,7 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     most_similar_reference = reference
 
             if most_similar_reference is not None:
+                count += 1
                 yield BibitemMatch(
                     bibitem.id_,
                     bibitem.text,
@@ -92,6 +94,8 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
                     bibitem.id_,
                     item.arxiv_id,
                 )
+        if item.bibitems and count == 0:
+            logging.warning(f"Could not match any reference for paper {item.arxiv_id}.")
 
     def save(self, item: MatchTask, result: BibitemMatch) -> None:
         resolutions_dir = directories.arxiv_subdir("bibitem-resolutions", item.arxiv_id)

--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -98,7 +98,8 @@ class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):
         if item.bibitems:
             if ref_match_count == 0:
                 logging.warning(
-                    f"Paper has reference(s), but could not match any to S2 reference data. Paper ID {item.arxiv_id}."
+                    f"Paper {item.arxiv_id} has {len(item.bibitems)} reference(s), " +
+                    f"but could not match any to S2 reference data."
                 )
             else:
                 logging.info(


### PR DESCRIPTION
For a paper, we extract references from the latex and try to match them with S2's reference data. This is to add a warning if we can't match any reference. This is to get more visibility into `no_citations` error. With this, we can know whether that error is caused by scholarphi not being able to extract any reference vs being able to extract reference but can't match it.

![Screen Shot 2021-04-16 at 11 02 38](https://user-images.githubusercontent.com/52424731/115065672-4508e200-9ea3-11eb-8983-0750a63a317f.png)