### PR TITLE
Remove "save to library"

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -84,8 +84,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
       entities: null,
       lazyPapers: new Map(),
 
-      userLibrary: null,
-
       pages: null,
       pdfViewerApplication: null,
       pdfDocument: null,
@@ -153,23 +151,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
     this.setState({
       [setting.key]: value,
     } as State);
-  }
-
-  addToLibrary = async (paperId: string, paperTitle: string): Promise<void> => {
-    if (this.props.paperId) {
-      const response = await api.addLibraryEntry(paperId, paperTitle);
-
-      if (!response) {
-        // Request failed, throw an error
-        throw new Error("Failed to add entry to library.");
-      }
-
-      const userLibrary = this.state.userLibrary;
-      if (userLibrary) {
-        const paperIds = userLibrary.paperIds.concat(paperId);
-        this.setState({ userLibrary: { ...userLibrary, paperIds } });
-      }
-    }
   }
 
   setTextSelection = (selection: Selection | null): void => {
@@ -745,14 +726,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
         const loadingTimeMS = Math.round(performance.now() - loadingStartTime);
         window.heap.track("paper-loaded", { loadingTimeMS, numEntities: entities.length, numCitations: citationS2Ids.length });
       }
-
-      const userData = await api.getUserLibraryInfo();
-      if (userData) {
-        this.setState({ userLibrary: userData.userLibrary });
-        if (userData.email) {
-          logger.setUsername(userData.email);
-        }
-      }
     }
   }
 
@@ -1127,7 +1100,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                         entities={entities}
                         lazyPapers={this.state.lazyPapers}
                         cachePaper={this.cachePaper}
-                        userLibrary={this.state.userLibrary}
                         selectedEntityIds={selectedEntityIds}
                         selectedAnnotationIds={selectedAnnotationIds}
                         selectedAnnotationSpanIds={selectedAnnotationSpanIds}
@@ -1158,7 +1130,6 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                           this.selectEntityAnnotation
                         }
                         handleShowSnackbarMessage={this.showSnackbarMessage}
-                        handleAddPaperToLibrary={this.addToLibrary}
                         handleJumpToEntity={this.jumpToEntityWithBackMessage}
                         handleOpenDrawer={this.openDrawer}
                       />

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -1,7 +1,5 @@
 import axios, { AxiosResponse } from "axios";
 import cookie from "cookie";
-import { addLibraryEntryUrl, userInfoUrl } from "./s2-url";
-import { UserInfo, UserLibrary } from "../state";
 import {
   Entity,
   EntityCreateData,
@@ -321,33 +319,6 @@ export async function deleteEntity(
     response
   );
   return false;
-}
-
-export async function addLibraryEntry(paperId: string, paperTitle: string) {
-  const folders: number[] = [];
-  const response = await axios.post(
-    addLibraryEntryUrl,
-    {
-      paperId,
-      paperTitle,
-      folders,
-    },
-    { withCredentials: true }
-  );
-  return response.data;
-}
-
-export async function getUserLibraryInfo() {
-  const data = await doGet(
-    axios.get<UserInfo>(userInfoUrl, { withCredentials: true })
-  );
-  if (data) {
-    const userLibrary: UserLibrary = {
-      paperIds: data.entriesWithPaperIds.map((entry) => entry[1]),
-    };
-    const email = data.user.email;
-    return { email, userLibrary };
-  }
 }
 
 /**

--- a/ui/src/api/s2-url.ts
+++ b/ui/src/api/s2-url.ts
@@ -1,6 +1,0 @@
-
-const utmSource = '?utm_source=augmented_reader';
-
-export const userInfoUrl = 'https://www.semanticscholar.org/api/1/user' + utmSource;
-export const userLibraryUrl = 'https://www.semanticscholar.org/me/library' + utmSource;
-export const addLibraryEntryUrl = 'https://www.semanticscholar.org/api/1/library/entries' + utmSource;

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../api/types";
 import * as selectors from "../../selectors";
 import { GlossStyle } from "../../settings";
-import { Entities, PaperId, UserLibrary } from "../../state";
+import { Entities, PaperId } from "../../state";
 import { PDFPageView } from "../../types/pdfjs-viewer";
 import * as uiUtils from "../../utils/ui";
 import { DrawerContentType } from "../drawer/Drawer";
@@ -27,7 +27,6 @@ interface Props {
   pageView: PDFPageView;
   entities: Entities;
   lazyPapers: Map<string, Paper>;
-  userLibrary: UserLibrary | null;
   selectedEntityIds: string[];
   selectedAnnotationIds: string[];
   selectedAnnotationSpanIds: string[];
@@ -50,13 +49,12 @@ interface Props {
     spanId: string
   ) => void;
   handleShowSnackbarMessage: (message: string) => void;
-  handleAddPaperToLibrary: (paperId: string, paperTitle: string) => void;
   handleJumpToEntity: (entityId: string) => void;
   handleOpenDrawer: (contentType: DrawerContentType) => void;
   cachePaper: (paper: Paper) => void;
 }
 
-class EntityAnnotationLayer extends React.Component<Props, {}> {
+class EntityAnnotationLayer extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
     this.onClickSentence = this.onClickSentence.bind(this);
@@ -160,7 +158,6 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
       entities,
       lazyPapers,
       cachePaper,
-      userLibrary,
       selectedEntityIds,
       selectedAnnotationIds,
       selectedAnnotationSpanIds,
@@ -177,7 +174,6 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
       termAnnotationsEnabled,
       equationDiagramsEnabled,
       copySentenceOnClick,
-      handleAddPaperToLibrary,
       handleSelectEntityAnnotation,
     } = this.props;
 
@@ -287,8 +283,6 @@ class EntityAnnotationLayer extends React.Component<Props, {}> {
                     <LazyCitationGloss
                       citation={entity}
                       lazyPapers={lazyPapers}
-                      userLibrary={userLibrary}
-                      handleAddPaperToLibrary={handleAddPaperToLibrary}
                       openedPaperId={paperId}
                       evaluationEnabled={glossEvaluationEnabled}
                       cachePaper={cachePaper}

--- a/ui/src/components/entity/citation/CitationGloss.tsx
+++ b/ui/src/components/entity/citation/CitationGloss.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import PaperSummary from "./PaperSummary";
-import { PaperId, UserLibrary } from "../../../state";
+import { PaperId } from "../../../state";
 import { Citation, Paper } from "../../../api/types";
 import { VoteButton } from "../../common";
 
 interface Props {
   paper: Paper;
   citation: Citation;
-  userLibrary: UserLibrary | null;
-  handleAddPaperToLibrary: (paperId: string, paperTitle: string) => void;
   openedPaperId?: PaperId;
   evaluationEnabled?: boolean;
 }
@@ -20,8 +18,6 @@ export class CitationGloss extends React.PureComponent<Props> {
         <div className="gloss__section">
           <PaperSummary
             paper={this.props.paper}
-            userLibrary={this.props.userLibrary}
-            handleAddPaperToLibrary={this.props.handleAddPaperToLibrary}
             openedPaperId={this.props.openedPaperId}
           />
         </div>

--- a/ui/src/components/entity/citation/LazyCitationGloss.tsx
+++ b/ui/src/components/entity/citation/LazyCitationGloss.tsx
@@ -1,21 +1,18 @@
 import React from "react";
 import PaperSummary from "./PaperSummary";
-import { PaperId, UserLibrary } from "../../../state";
+import { PaperId } from "../../../state";
 import { Citation, Paper } from "../../../api/types";
 import { VoteButton } from "../../common";
 import { Nullable } from '../../../types/ui';
 import { getPaper } from '../../../api/api';
 import { LinearProgress } from "@material-ui/core";
-import { AxiosError } from "axios";
 
 interface Props {
   citation: Citation;
   lazyPapers: Map<string, Paper>;
   cachePaper: (paper: Paper, cb?: () => void) => void;
   evaluationEnabled?: boolean;
-  handleAddPaperToLibrary: (paperId: string, paperTitle: string) => void;
   openedPaperId?: PaperId;
-  userLibrary: Nullable<UserLibrary>;
 }
 
 interface State {
@@ -87,8 +84,6 @@ export default class LazyCitationGloss extends React.PureComponent<Props, State>
     const paperComponent = !!paper ? (
       <PaperSummary
             paper={paper}
-            userLibrary={this.props.userLibrary}
-            handleAddPaperToLibrary={this.props.handleAddPaperToLibrary}
             openedPaperId={this.props.openedPaperId}
           />
     ) : noPaperComponent;

--- a/ui/src/components/entity/citation/PaperSummary.tsx
+++ b/ui/src/components/entity/citation/PaperSummary.tsx
@@ -7,85 +7,28 @@ import {
   InboundCitationIcon,
   OutboundCitationIcon,
 } from "../../icon";
-import logger from "../../../logging";
-import { userLibraryUrl } from "../../../api/s2-url";
 import S2Link from "./S2Link";
-import { PaperId, UserLibrary } from "../../../state";
+import { PaperId } from "../../../state";
 import { Paper } from "../../../api/types";
 import PaperAbstract from "./PaperAbstract";
 
-import Button from "@material-ui/core/Button";
 import Tooltip from "@material-ui/core/Tooltip";
-import SaveIcon from "@material-ui/icons/Bookmark";
 import React from "react";
 
 interface Props {
   paper: Paper;
-  userLibrary: UserLibrary | null;
-  handleAddPaperToLibrary: (paperId: string, paperTitle: string) => void;
   openedPaperId?: PaperId;
 }
 
-interface State {
-  showFullAbstract: boolean;
-  showLoginMessage: boolean;
-  errorMessage: string;
-}
-
-function goToLibrary() {
-  window.open(userLibraryUrl, "_blank");
-}
-
-function trackLibrarySave() {
-  if (window.heap) {
-    window.heap.track("Save to Library", { actionType: "save" });
-  }
-}
-
-export default class PaperSummary extends React.PureComponent<Props, State> {
-  state = {
-    showFullAbstract: false,
-    showLoginMessage: false,
-    errorMessage: "",
-  };
-
-  saveToLibrary = async (): Promise<void> => {
-    const { paper, userLibrary, handleAddPaperToLibrary } = this.props;
-    logger.log("debug", "citation-action", {
-      type: "save-to-library",
-      paper: paper,
-    });
-
-    if (!userLibrary) {
-      this.setState({
-        showLoginMessage: true,
-      });
-    } else {
-      try {
-        await handleAddPaperToLibrary(paper.s2Id, paper.title);
-        trackLibrarySave();
-        this.setState({
-          errorMessage: "",
-        });
-      } catch (error) {
-        this.setState({
-          errorMessage: "Cannot save to library at this time.",
-        });
-      }
-    }
-  };
-
+export default class PaperSummary extends React.PureComponent<Props> {
   render(): React.ReactNode {
-    const { paper, userLibrary } = this.props;
+    const { paper } = this.props;
 
     const hasMetrics =
       paper.citationVelocity ||
       paper.influentialCitationCount ||
       paper.inboundCitations ||
       paper.outboundCitations;
-    const inLibrary = userLibrary
-      ? userLibrary.paperIds.includes(paper.s2Id)
-      : false;
 
     return (
       <div className="paper-summary">
@@ -192,14 +135,6 @@ export default class PaperSummary extends React.PureComponent<Props, State> {
               ) : null}
             </div>
           ) : null}
-          {inLibrary ? (
-            <LibraryButton label="In Your Library" onClick={goToLibrary} />
-          ) : (
-            <LibraryButton
-              label="Save To Library"
-              onClick={this.saveToLibrary}
-            />
-          )}
         </div>
 
         <div className="paper-summary__section paper-summary__feedback">
@@ -209,40 +144,7 @@ export default class PaperSummary extends React.PureComponent<Props, State> {
             extraContext={{ paperId: paper.s2Id }}
           />
         </div>
-
-        <div className="paper-summary__library-error">
-          {!!this.state.errorMessage && this.state.errorMessage}
-          {this.state.showLoginMessage && (
-            <>
-              Before you can save papers to your library, you must be logged
-              into Semantic Scholar. Visit{" "}
-              <ExternalLink
-                href="https://www.semanticscholar.org/me/library"
-                allowReferrer
-              >
-                Semantic Scholar
-              </ExternalLink>{" "}
-              to log in. Then refresh this page and try again.
-            </>
-          )}
-        </div>
       </div>
     );
   }
 }
-
-const LibraryButton = (props: {
-  label: string;
-  onClick: () => void;
-}): React.ReactElement => {
-  const { label, onClick } = props;
-  return (
-    <Button
-      startIcon={<SaveIcon />}
-      className="paper-summary__action"
-      onClick={onClick}
-    >
-      {label}
-    </Button>
-  );
-};

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -48,11 +48,6 @@ export interface State extends Settings {
   lazyPapers: Map<string, Paper>;
 
   /*
-   * *** USER LIBRARY DATA ***
-   */
-  userLibrary: UserLibrary | null;
-
-  /*
    * *** PDF.JS OBJECTS ***
    */
   pages: Readonly<Pages> | null;
@@ -171,10 +166,6 @@ export interface UserInfo {
     email: string | null;
   };
   entriesWithPaperIds: [number, string][];
-}
-
-export interface UserLibrary {
-  paperIds: string[];
 }
 
 export type Pages = { [pageNumber: number]: PageModel };

--- a/ui/src/style/paper-summary.less
+++ b/ui/src/style/paper-summary.less
@@ -73,18 +73,12 @@
   }
 }
 
-.paper-summary__library-error {
-  color: @s2-error;
-}
-
 /**
  * Metrics
  */
 
 .paper-summary__metrics {
   display: flex;
-  border-right: 1px solid @s2-border-light;
-  margin-right: @padding;
 }
 
 .paper-summary__metrics__metric {


### PR DESCRIPTION
This is implemented using S2 private APIs, which we don't want to be using, so it seems like a good idea to remove it prior to getting a bunch of public eyes on the reader. I wanted to do this a separate change from my previous PR so it could be more easily reverted if we come up with a way to support this on the S2 side without needing the reader to call private APIs.