### PR TITLE
Bugfix: fix NoneType bug in equation parser

### DIFF
--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -831,7 +831,7 @@ class MathMlElementMerger:
         tag_name = elements[0].name
 
         # Create a new BeautifulSoup object with the contents of all identifiers appended together.
-        new_text = "".join([n.string for n in elements])
+        new_text = "".join([n.string for n in elements if n.string is not None])
         element = create_element(tag_name)
         element.string = new_text
         element.attrs["s2:start"] = elements[0].attrs["s2:start"]

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -831,6 +831,12 @@ class MathMlElementMerger:
         tag_name = elements[0].name
 
         # Create a new BeautifulSoup object with the contents of all identifiers appended together.
+        # TODO(andrewhead): The guard below for `n.string is not None` is a workaround for the
+        # exception that is encountered when one of the elements being merged has child element
+        # of its own. Ideally, the guard should not be needed, and instead, the caller of this method should
+        # check that an element has no children before marking it as capable of being merged. arXiv
+        # paper 1612.03144v2 will reproduce the error if the guard is removed.
+        # See https://github.com/allenai/scholarphi/pull/279.
         new_text = "".join([n.string for n in elements if n.string is not None])
         element = create_element(tag_name)
         element.string = new_text


### PR DESCRIPTION
This commit fixes a TypeError that was raised when certain idiomatic MathML formulas were getting parsed. The issue was that if `element.string` is called on an element that has multiple children, `None` was returned, instead of a text representation of the contents of the string.

This fix is a temporary workaround to the issue. The good thing is that the change is minimal, providing graceful degradation of behavior when something unexpected happens (i.e., when an element has multiple children). The bad thing is that this still might not be the ideal behavior; ideally, two elements should not be merged together in this function if one of them has multiple children. However, in the spirit of expedient changes that improve paper coverage without introducing new surface area for bugs, I opted for the current fix.