### PR TITLE
UI: Fix padding of brand bar in Safari

### DIFF
--- a/ui/src/style/brandbar.less
+++ b/ui/src/style/brandbar.less
@@ -41,13 +41,14 @@
   .brandbar__seperator {
     margin: -3px 10px;
 
-    border-left: 1px solid #D9DADB;
+    border-left: 1px solid #d9dadb;
   }
 
   .brandbar__s2-logo {
     margin-top: -4px;
     margin-right: 5px;
     width: 28px;
+    height: 22px;
 
     .brandbar__s2-logo__wordmark {
       fill: @logo-blue-1;


### PR DESCRIPTION
Addresses #27673

The issue with padding in the brand bar for Safari seemed to be caused by the Semanti Scholar logo being rendered at a large height by default. When I hard-coded the height, the logo reappeared, and the padding issues resolved.

Here is the brand bar in Safari after the fix:

![image](https://user-images.githubusercontent.com/2358524/116894137-95dc4280-abe6-11eb-9632-ec47dc8e5ed4.png)

This fix was verified both in Safari and in a recent version of Chrome.