### PR TITLE
Optional highlighting

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -45,12 +45,43 @@ if (params.preset instanceof Array) {
   presets = [params.preset];
 }
 
-if (params.annotationMode !== undefined) {
+if (params.annotateCitations !== undefined) {
   const element = document.createElement("style");
   document.head.appendChild(element);
 
   if (element.sheet) {
-    element.sheet.insertRule(".symbol-annotation { background-color: rgba(255, 0, 0, 0.1) !important; }", 0);
+    element.sheet.insertRule(`
+        .citation-annotation { 
+            background-color: rgba(0, 0, 255, 0.1) !important; 
+        }`,
+      0);
+  }
+}
+
+if (params.annotateSymbols !== undefined) {
+  const element = document.createElement("style");
+  document.head.appendChild(element);
+
+  if (element.sheet) {
+    element.sheet.insertRule(`
+        .symbol-annotation { 
+            background-color: rgba(255, 0, 0, 0.1) !important; 
+            border: 1px solid rgba(0, 0, 0, 0.1) !important;
+        }`,
+      0);
+  }
+}
+
+if (params.annotateEquations !== undefined) {
+  const element = document.createElement("style");
+  document.head.appendChild(element);
+
+  if (element.sheet) {
+    element.sheet.insertRule(`
+        .equation-annotation { 
+            background-color: rgba(0, 255, 0, 0.1) !important; 
+        }`,
+      0);
   }
 }
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -45,6 +45,15 @@ if (params.preset instanceof Array) {
   presets = [params.preset];
 }
 
+if (params.annotationMode !== undefined) {
+  const element = document.createElement("style");
+  document.head.appendChild(element);
+
+  if (element.sheet) {
+    element.sheet.insertRule(".symbol-annotation { background-color: rgba(255, 0, 0, 0.1) !important; }", 0);
+  }
+}
+
 let context: any = {};
 if (typeof params.p === "string") {
   context.userId = params.p;


### PR DESCRIPTION
Per @kyleclo 's request, an optional query parameters can now 
be passed that will highlight entities that we care about manually evaluating.

Simple append one or more of the following to your URL:

```
&annotateEquations
&annotateSymbols
&annotateCitations
```

Results in things like:

<img width="726" alt="Screen Shot 2021-05-03 at 12 21 49 PM" src="https://user-images.githubusercontent.com/1287054/116922510-5889ac00-ac0a-11eb-9453-d008940d5c82.png">

