### PR TITLE
UI: Disable equation diagrams

### DIFF
--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -147,7 +147,7 @@ export function getSettings(presets?: string[]) {
     symbolSearchEnabled: true,
     declutterEnabled: true,
     definitionPreviewEnabled: false,
-    equationDiagramsEnabled: true,
+    equationDiagramsEnabled: false,
     useDefinitionsForDiagramLabels: false,
     entityCreationEnabled: false,
     entityEditingEnabled: false,


### PR DESCRIPTION
As I understand, the demo for CHI 2021 will likely not include features like equation diagrams, which expose definition information about symbols.

This PR disables equation diagrams. The end result is that equations are no longer selectable, though the symbols that they are made up of still are. So instead of having selectable equations (before):

![image](https://user-images.githubusercontent.com/2358524/116929922-ef0e9b00-ac13-11eb-8707-c4626b6f46d0.png)

Now readers can click on individual symbols (after):

![image](https://user-images.githubusercontent.com/2358524/116929949-f766d600-ac13-11eb-87ee-09413353d0ac.png)