### PR TITLE
UI: Disable tooltips for symbols; underline all top-level symbols

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -1115,6 +1115,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                           this.state.citationGlossesEnabled
                         }
                         termAnnotationsEnabled={this.state.termGlossesEnabled}
+                        symbolGlossesEnabled={this.state.symbolGlossesEnabled}
                         symbolUnderlineMethod={this.state.symbolUnderlineMethod}
                         glossStyle={this.state.glossStyle}
                         glossEvaluationEnabled={

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -40,6 +40,7 @@ interface Props {
   glossEvaluationEnabled: boolean;
   citationAnnotationsEnabled: boolean;
   termAnnotationsEnabled: boolean;
+  symbolGlossesEnabled: boolean;
   symbolUnderlineMethod: SymbolUnderlineMethod;
   equationDiagramsEnabled: boolean;
   copySentenceOnClick: boolean;
@@ -172,6 +173,7 @@ class EntityAnnotationLayer extends React.Component<Props> {
       citationAnnotationsEnabled,
       symbolUnderlineMethod,
       termAnnotationsEnabled,
+      symbolGlossesEnabled,
       equationDiagramsEnabled,
       copySentenceOnClick,
       handleSelectEntityAnnotation,
@@ -426,6 +428,7 @@ class EntityAnnotationLayer extends React.Component<Props> {
                 glossStyle={glossStyle}
                 glossContent={
                   showGlosses &&
+                  symbolGlossesEnabled &&
                   !(this.props.glossStyle === "tooltip" && !isFindSelection) ? (
                     <SimpleSymbolGloss
                       symbol={entity}

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -41,6 +41,10 @@ export interface Settings {
    */
   termGlossesEnabled: boolean;
   /**
+   * Show glosses for symbols.
+   */
+  symbolGlossesEnabled: boolean;
+  /**
    * How to determine whether to underline a symbol. For example, underlines can be placed
    * underneath all symbols with a definition, or under all top-level symbols.
    */
@@ -143,6 +147,7 @@ export function getSettings(presets?: string[]) {
     textSelectionMenuEnabled: false,
     citationGlossesEnabled: true,
     termGlossesEnabled: false,
+    symbolGlossesEnabled: false,
     symbolUnderlineMethod: "defined-symbols",
     symbolSearchEnabled: true,
     declutterEnabled: true,

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -148,7 +148,7 @@ export function getSettings(presets?: string[]) {
     citationGlossesEnabled: true,
     termGlossesEnabled: false,
     symbolGlossesEnabled: false,
-    symbolUnderlineMethod: "defined-symbols",
+    symbolUnderlineMethod: "top-level-symbols",
     symbolSearchEnabled: true,
     declutterEnabled: true,
     definitionPreviewEnabled: false,
@@ -228,6 +228,11 @@ export const CONFIGURABLE_SETTINGS: ConfigurableSetting[] = [
     key: "citationGlossesEnabled",
     type: "flag",
     label: "Citation glosses",
+  },
+  {
+    key: "symbolGlossesEnabled",
+    type: "flag",
+    label: "Symbol glosses",
   },
   {
     key: "symbolSearchEnabled",

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -147,7 +147,7 @@ export function getSettings(presets?: string[]) {
     symbolSearchEnabled: true,
     declutterEnabled: true,
     definitionPreviewEnabled: false,
-    equationDiagramsEnabled: true,
+    equationDiagramsEnabled: false,
     useDefinitionsForDiagramLabels: false,
     entityCreationEnabled: false,
     entityEditingEnabled: false,


### PR DESCRIPTION
According to current plans, symbol definition tooltips will not be shown in the upcoming ScholarPhi demo. This PR makes two changes to the UI to make the interactions better support declutter-centric interactions with symbols.

1. The definition tooltip (which would not have any definitions to show) is now hidden (toggled off using the new `symbolGlossesEnabled` setting).
2. Underlines are now placed underneath _all_ top-level symbols, and not just the symbols that have definitions available (as technically, none of the symbols will have definitions available anymore). This should make it clearer to readers what symbols they can interact with.

Before:

![image](https://user-images.githubusercontent.com/2358524/116930285-67755c00-ac14-11eb-910c-44c056365d32.png)

After (no tooltip; `L_CGAN` symbol which did not have a definition before is now underlined): 

![image](https://user-images.githubusercontent.com/2358524/116931415-cd161800-ac15-11eb-9922-3b01f3da85a5.png)
