### PR TITLE
UI: show underlines for all top-level symbols (not just those with de…

### DIFF
--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -143,7 +143,7 @@ export function getSettings(presets?: string[]) {
     textSelectionMenuEnabled: false,
     citationGlossesEnabled: true,
     termGlossesEnabled: false,
-    symbolUnderlineMethod: "defined-symbols",
+    symbolUnderlineMethod: "top-level-symbols",
     symbolSearchEnabled: true,
     declutterEnabled: true,
     definitionPreviewEnabled: false,


### PR DESCRIPTION
To indicate to readers where it is possible to use "declutter", I swapped a settings flag to make sure that all top-level symbols in a paper are underlined (and hence indicate that they are interactive), instead of just those that have definitions.

Before:

![image](https://user-images.githubusercontent.com/2358524/117040749-10789100-acbf-11eb-8a82-c37a0d5473ea.png)

After (see additional underlines beneath 'z' and 'y'):

![image](https://user-images.githubusercontent.com/2358524/117040758-12daeb00-acbf-11eb-8f21-d7ffcd40e1ff.png)