### PR TITLE
Turns off definitional features.

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -986,6 +986,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
             pages={this.state.pages}
             entities={this.state.entities}
             annotationHintsEnabled={this.state.annotationHintsEnabled}
+            primerPageGlossaryEnabled={this.state.primerPageGlossaryEnabled}
             termGlossesEnabled={this.state.termGlossesEnabled}
             showInstructions={this.state.primerInstructionsEnabled}
             scrollToPageOnLoad={this.state.initialFocus === null}
@@ -1116,6 +1117,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                         }
                         termAnnotationsEnabled={this.state.termGlossesEnabled}
                         symbolUnderlineMethod={this.state.symbolUnderlineMethod}
+                        definitionsInSymbolGloss={this.state.definitionsInSymbolGloss}
                         glossStyle={this.state.glossStyle}
                         glossEvaluationEnabled={
                           this.state.glossEvaluationEnabled

--- a/ui/src/components/entity/EntityAnnotationLayer.tsx
+++ b/ui/src/components/entity/EntityAnnotationLayer.tsx
@@ -41,6 +41,7 @@ interface Props {
   citationAnnotationsEnabled: boolean;
   termAnnotationsEnabled: boolean;
   symbolUnderlineMethod: SymbolUnderlineMethod;
+  definitionsInSymbolGloss: boolean;
   equationDiagramsEnabled: boolean;
   copySentenceOnClick: boolean;
   handleSelectEntityAnnotation: (
@@ -433,6 +434,7 @@ class EntityAnnotationLayer extends React.Component<Props> {
                       showDrawerActions={true}
                       handleJumpToEntity={this.props.handleJumpToEntity}
                       handleOpenDrawer={this.props.handleOpenDrawer}
+                      definitionsEnabled={this.props.definitionsInSymbolGloss}
                     />
                   ) : null
                 }

--- a/ui/src/components/entity/SimpleSymbolGloss.tsx
+++ b/ui/src/components/entity/SimpleSymbolGloss.tsx
@@ -22,6 +22,7 @@ interface Props {
   showDrawerActions?: boolean;
   handleOpenDrawer: (contentType: DrawerContentType) => void;
   handleJumpToEntity: (entityId: string) => void;
+  definitionsEnabled: boolean;
 }
 
 interface State {
@@ -69,7 +70,7 @@ class SimpleSymbolGloss extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { entities, symbol } = this.props;
+    const { entities, symbol, definitionsEnabled } = this.props;
 
     /*
      * Try to find definition and nickname right before the symbol.
@@ -128,7 +129,7 @@ class SimpleSymbolGloss extends React.PureComponent<Props, State> {
         <table>
           <tbody>
             <tr>
-              {(definedHere || definition || nickname) && (
+              {(definitionsEnabled && (definedHere || definition || nickname)) && (
                 <td>
                   <div className="simple-gloss__definition-container">
                     {definedHere && <p>Defined here.</p>}
@@ -168,23 +169,25 @@ class SimpleSymbolGloss extends React.PureComponent<Props, State> {
               )}
               {this.props.showDrawerActions && (
                 <React.Fragment>
-                  <td>
-                    <MuiTooltip
-                      title={
-                        defsAndNicknames.length > 0
-                          ? `See ${defsAndNicknames.length} definitions`
-                          : "No definitions."
-                      }
-                    >
-                      <IconButton
-                        size="small"
-                        disabled={defsAndNicknames.length === 0}
-                        onClick={this.onClickDefinitionsButton}
+                  {definitionsEnabled && (
+                    <td>
+                      <MuiTooltip
+                        title={
+                          defsAndNicknames.length > 0
+                            ? `See ${defsAndNicknames.length} definitions`
+                            : "No definitions."
+                        }
                       >
-                        <MenuBook />
-                      </IconButton>
-                    </MuiTooltip>
-                  </td>
+                        <IconButton
+                          size="small"
+                          disabled={defsAndNicknames.length === 0}
+                          onClick={this.onClickDefinitionsButton}
+                        >
+                          <MenuBook />
+                        </IconButton>
+                      </MuiTooltip>
+                    </td>
+                  )}
                   <td>
                     <MuiTooltip
                       title={

--- a/ui/src/components/primer/PrimerPage.tsx
+++ b/ui/src/components/primer/PrimerPage.tsx
@@ -17,6 +17,7 @@ interface Props {
   entities: Entities | null;
   showInstructions: boolean;
   annotationHintsEnabled: boolean;
+  primerPageGlossaryEnabled: boolean;
   termGlossesEnabled: boolean;
   scrollToPageOnLoad?: boolean;
   areCitationsLoading?: boolean;
@@ -67,6 +68,7 @@ class PrimerPage extends React.PureComponent<Props> {
     const {
       pages,
       entities,
+      primerPageGlossaryEnabled,
       showInstructions,
       termGlossesEnabled,
       areCitationsLoading,
@@ -195,7 +197,7 @@ class PrimerPage extends React.PureComponent<Props> {
           }
           {isEntitiesLoaded(entities) && (
             <>
-              {termGlossesEnabled && terms.length > 0 ? (
+              {primerPageGlossaryEnabled && termGlossesEnabled && terms.length > 0 ? (
                 <>
                   <p className="primer-page__header">Glossary of key terms</p>
                   <p className="primer-page__subheader">
@@ -214,7 +216,7 @@ class PrimerPage extends React.PureComponent<Props> {
                   </div>
                 </>
               ) : null}
-              {symbols.length > 0 ? (
+              {primerPageGlossaryEnabled && symbols.length > 0 ? (
                 <>
                   <p className="primer-page__header">
                     Glossary of key {terms.length === 0 && "terms and "} symbols

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -13,6 +13,10 @@ export interface Settings {
    */
   primerPageEnabled: boolean;
   /**
+   * Whether or not to show term and symbol glossary on primer page
+   */
+  primerPageGlossaryEnabled: boolean;
+  /**
    * Show instructions in the primer describing how to use the tool.
    */
   primerInstructionsEnabled: boolean;
@@ -49,6 +53,10 @@ export interface Settings {
    * Start a within-paper symbol search when a symbol is selected.
    */
   symbolSearchEnabled: boolean;
+  /**
+   * Whether to show definition related features in symbol gloss
+   */
+  definitionsInSymbolGloss: boolean;
   /**
    * Enable the 'declutter' interaction which masks pages to show only those sentences that
    * contain an entity that the user selected.
@@ -134,6 +142,7 @@ const PRESETS: Preset[] = [
 export function getSettings(presets?: string[]) {
   const DEFAULT_SETTINGS: Settings = {
     primerPageEnabled: true,
+    primerPageGlossaryEnabled: false,
     primerInstructionsEnabled: true,
     annotationInteractionEnabled: true,
     annotationHintsEnabled: true,
@@ -142,12 +151,13 @@ export function getSettings(presets?: string[]) {
     glossStyle: "tooltip",
     textSelectionMenuEnabled: false,
     citationGlossesEnabled: true,
+    definitionsInSymbolGloss: false,
     termGlossesEnabled: false,
     symbolUnderlineMethod: "defined-symbols",
     symbolSearchEnabled: true,
     declutterEnabled: true,
     definitionPreviewEnabled: false,
-    equationDiagramsEnabled: true,
+    equationDiagramsEnabled: false,
     useDefinitionsForDiagramLabels: false,
     entityCreationEnabled: false,
     entityEditingEnabled: false,


### PR DESCRIPTION
* hides primer page glossary behind
      flag that is off for CHI
* hides definitional bits of the symbol
      gloss behind new FF
* turns off equation diagrams using existing
      FF

<img width="325" alt="Screen Shot 2021-05-05 at 12 39 45 PM" src="https://user-images.githubusercontent.com/1287054/117199399-0037e300-ad9f-11eb-9983-d563859d7df9.png">
