### PR TITLE
adding skiff stats

### DIFF
--- a/ui/public/viewer.html
+++ b/ui/public/viewer.html
@@ -82,6 +82,7 @@ See https://github.com/adobe-type-tools/cmap-resources
         });
       heap.load("3075009564");
     </script>
+    <script src="https://stats.allenai.org/init.min.js" data-app-name="s2-reader" async></script>
 
 
 


### PR DESCRIPTION
A simple add of the skiff stats.
While I was in here though I noticed that this app already uses a analytics tracker called "Heap". I was wondering if it is desired to support them both? (Are we even still using Heap?)