### PR TITLE
Reduce use of 'master' language

### DIFF
--- a/.skiff/cloudbuild-deploy.yaml
+++ b/.skiff/cloudbuild-deploy.yaml
@@ -1,6 +1,6 @@
 # This file tells Google Cloud Build how to deploy the application.
 # It can be attached to a variety of triggers, the default being whenever
-# someone merges changes to the `master` branch.
+# someone merges changes to the main branch.
 steps:
 # Pull down the latest versions of each Docker image, so the build is faster.
 - id: 'api.pull'

--- a/data-processing/common/scan_tex.py
+++ b/data-processing/common/scan_tex.py
@@ -97,7 +97,7 @@ class TexScanner:
         """
         scan_patterns = PRIVATE_PATTERNS + list(patterns)
 
-        # Create a master regular expression pattern for all input patterns.
+        # Create a universal regular expression pattern for all input patterns.
         patterns_by_name = {p.name: p for p in scan_patterns}
         regexes = []
         for p in scan_patterns:

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -13,7 +13,7 @@ import EntityPageMask from "./components/mask/EntityPageMask";
 import EquationDiagram from "./components/entity/equation/EquationDiagram";
 import FindBar, { FindQuery } from "./components/search/FindBar";
 import logger from "./logging";
-import MasterControlPanel from "./components/control/MasterControlPanel";
+import MainControlPanel from "./components/control/MainControlPanel";
 import PageOverlay from "./components/overlay/PageOverlay";
 import PdfjsToolbar from "./components/pdfjs/PdfjsToolbar";
 import PdfjsBrandbar from "./components/pdfjs/PdfjsBrandbar";
@@ -871,7 +871,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                 })}
               >
                 {this.state.controlPanelShowing ? (
-                  <MasterControlPanel
+                  <MainControlPanel
                     className="scholar-reader-toolbar"
                     handleClose={this.closeControlPanel}
                   >
@@ -883,7 +883,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                         handleChange={this.handleChangeSetting}
                       />
                     ))}
-                  </MasterControlPanel>
+                  </MainControlPanel>
                 ) : null}
                 {this.state.isFindActive &&
                 this.state.findActivationTimeMs !== null &&

--- a/ui/src/components/control/MainControlPanel.tsx
+++ b/ui/src/components/control/MainControlPanel.tsx
@@ -14,7 +14,7 @@ interface Props {
  * Control panel for turning turn on or off features of the user interface. Meant for use by
  * developers, or by participants in usability studies.
  */
-class MasterControlPanel extends React.PureComponent<Props> {
+class MainControlPanel extends React.PureComponent<Props> {
   render() {
     return (
       <Card
@@ -41,4 +41,4 @@ class MasterControlPanel extends React.PureComponent<Props> {
   }
 }
 
-export default MasterControlPanel;
+export default MainControlPanel;


### PR DESCRIPTION
Use of the word "master" in many technology contexts is broadly accepted to be [racist language](https://www.google.com/search?q=master+racist+language).  This change removes some of these terms in favor of "main".