### PR TITLE
Add a pod disruption budget, and surge during deploys.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -147,6 +147,12 @@ function(
             }
         },
         spec: {
+            strategy: {
+                type: 'RollingUpdate',
+                rollingUpdate: {
+                    maxSurge: replicas // This makes deployments faster.
+                }
+            },
             revisionHistoryLimit: 3,
             replicas: replicas,
             selector: {
@@ -253,9 +259,26 @@ function(
         }
     };
 
+    local pdb = {
+        apiVersion: 'policy/v1beta1',
+        kind: 'PodDisruptionBudget',
+        metadata: {
+            name: fullyQualifiedName,
+            namespace: namespaceName,
+            labels: labels,
+        },
+        spec: {
+            minAvailable: if replicas > 1 then 1 else 0,
+            selector: {
+                matchLabels: selectorLabels,
+            },
+        },
+    };
+
     [
         namespace,
         ingress,
         deployment,
-        service
+        service,
+        pdb
     ]


### PR DESCRIPTION
This change does two things:

1. Adds a `PodDisruptionBudget`, which tells Kubernetes that there
   must always be `minAvailable` replicas up. In the case of production,
   this guarantees that there will always be at least one replica to
   handle incoming traffic. The main outcome of this being that
   there shouldn't be downtime anymore during cluster wide Kubernetes
   updates.

2. Updates the deployment specification so that Kubernetes can "surge"
   while deploying changes. This makes deployments faster by quickly
   deploying a full set of new replicas -- currently it does so
   in a rolling fashion. This makes things a little faster, and also
   ensures there's additional capacity during deploys.