### PR TITLE
Pipe through definitions base url argument

### DIFF
--- a/data-processing/README.md
+++ b/data-processing/README.md
@@ -202,6 +202,24 @@ Alternatively, you can run just the slow tests with:
 pytest -m slow
 ```
 
+### A note on tests around definitions
+
+Some tests around the definitions pipeline need to download
+some things. By default, they use this as the base url:
+
+```
+https://scholarphi.s3-us-west-1.amazonaws.com/
+```
+
+If you do not have access to the relevant bucket, those tests
+will fail. To use a different base url for the tests, export
+it as an environment variable called `DEFINITIONS_BASE_URL`
+before running the tests:
+
+```
+export DEFINITIONS_BASE_URL=<alternative base url>
+```
+
 ## Troubleshooting the installation
 
 ### Installing psycopg2

--- a/data-processing/entities/definitions/commands/detect_definitions.py
+++ b/data-processing/entities/definitions/commands/detect_definitions.py
@@ -602,7 +602,10 @@ class DetectDefinitions(
 
         # Load the pre-trained definition detection model.
         prediction_types = ["AI2020", "DocDef2", "W00"]
-        model = DefinitionDetectionModel(prediction_types)
+        if self.args.definitions_base_url is not None:
+            model = DefinitionDetectionModel(prediction_types, self.args.definitions_base_url)
+        else:
+            model = DefinitionDetectionModel(prediction_types)
 
         definition_index = 0
         features = []

--- a/data-processing/entities/definitions/nlp.py
+++ b/data-processing/entities/definitions/nlp.py
@@ -26,7 +26,11 @@ MODEL_CLASSES = {
 
 
 class DefinitionDetectionModel:
-    def __init__(self, prediction_types: List[str]) -> None:
+    def __init__(
+        self,
+        prediction_types: List[str],
+        base_url: str = "https://scholarphi.s3-us-west-1.amazonaws.com/"
+    ) -> None:
 
         # Initialize modules for featurization.
         # To use a smaller model, swap out the parameter with "en_core_sci_sm"
@@ -48,17 +52,17 @@ class DefinitionDetectionModel:
         # Initialize modules for transformer-based inference model based on the prediction_type
         self.model_paths = {
             "W00": {
-                "baseURL": "https://scholarphi.s3-us-west-1.amazonaws.com/",
+                "baseURL": base_url,
                 "file": "termdef.zip",
                 "type": "term-def",
             },
             "AI2020": {
-                "baseURL": "https://scholarphi.s3-us-west-1.amazonaws.com/",
+                "baseURL": base_url,
                 "file": "abbrexp.zip",
                 "type": "abbr-exp",
             },
             "DocDef2": {
-                "baseURL": "https://scholarphi.s3-us-west-1.amazonaws.com/",
+                "baseURL": base_url,
                 "file": "symnick.zip",
                 "type": "sym-nick",
             },

--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -28,6 +28,7 @@ from common.commands.store_results import DEFAULT_S3_LOGS_BUCKET, StoreResults
 from common.fetch_arxiv import FetchFromArxivException
 from common.make_digest import make_paper_digest
 from common.types import PipelineDigest
+from entities.definitions.commands.detect_definitions import DetectDefinitions
 
 from scripts.commands import (
     ENTITY_COMMANDS,
@@ -70,6 +71,8 @@ def run_commands_for_arxiv_ids(
             command_args.s3_bucket = pipeline_args.s3_arxiv_sources_bucket
         if CommandCls in [StorePipelineLog, StoreResults]:
             command_args.s3_bucket = pipeline_args.s3_output_bucket
+        if CommandCls == DetectDefinitions:
+            command_args.definitions_base_url = pipeline_args.definitions_base_url
 
         if CommandCls == StorePipelineLog:
             logging.debug("Flushing file log before storing pipeline logs.")
@@ -326,6 +329,11 @@ if __name__ == "__main__":
             "Version number to assign to the uploaded data. Defaults to creating a new version "
             + "number for each paper for each run of the pipeline."
         ),
+    )
+    parser.add_argument(
+        "--definitions-base-url",
+        type=str,
+        help="Base url for definition model paths."
     )
     args = parser.parse_args()
 

--- a/data-processing/tests/test_extract_definitions.py
+++ b/data-processing/tests/test_extract_definitions.py
@@ -2,6 +2,7 @@
 # how test fixtures (e.g., for initializing NLP models) are used in Pytest.
 # pylint: disable=redefined-outer-name
 
+import os
 import pytest
 from entities.definitions.commands.detect_definitions import (
     DefinitionDetectionModel,
@@ -13,7 +14,11 @@ from entities.definitions.commands.detect_definitions import (
 
 @pytest.fixture(scope="module")
 def model():
-    model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])
+    maybe_base_url = os.environ.get("DEFINITIONS_BASE_URL")
+    if maybe_base_url is None:
+        model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])
+    else:
+        model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"], maybe_base_url)
     return model
 
 


### PR DESCRIPTION
Some attempts to run the definitions pipeline in the chi-2021-demo branch fail with 404s. It seems like the problem is access to the bucket here: `https://scholarphi.s3-us-west-1.amazonaws.com/`, where some definition-related things are stored (see data-processing/entities/definitions/nlp.py).

This PR allows one to specify an alternative base url through a command line argument when one uses `scripts/run_pipeline.py`. If an alternative is not specified, the current base url is used.

To note:
- It is assumed that what is at any alternative provided location is the same as what is in `https://scholarphi.s3-us-west-1.amazonaws.com/` now.
- This change does mean that we now expect all three desired files to be found in the same place. I _think_ this is fine for now - we can adjust if we need more flexibility in the future.

Below I describe the things I did to try and test this - please let me know if there's anything else you'd like me to try!

Note: this PR is from my branch to the `chi-2021-demo` branch (rather than main), because I believe we're still running what's in the chi 2021 demo branch.

## Testing done

### Running the pipeline

I tried out more or less what is in this PR (adding an extra log line around what base url is being used). 

#### Without providing an alternative location:
```
python scripts/run_pipeline.py --one-paper-at-a-time --arxiv-ids "1601.00978v1" --dry-run --entities definitions  --keep-intermediate-files --keep-paper-data
...
2021-07-26 23:37:50,498 [INFO]: Launching command tokenize-sentences
2021-07-26 23:37:50,507 [WARNING]: Could not load child symbol SymbolId(tex_path='cratercnn.tex', equation_index=3, symbol_index=9) or parent symbol SymbolId(tex_path='cratercnn.tex', equation_index=3, symbol_index=4) for paper 1601.00978v1 when associating the two as parent and child. There may have been an error in the equation parser, like a failure to find tokens for the child symbol.
2021-07-26 23:37:52,178 [INFO]: Finished running command tokenize-sentences
2021-07-26 23:37:52,346 [INFO]: Launching command create-annotation-files
2021-07-26 23:37:52,495 [INFO]: Finished running command create-annotation-files
2021-07-26 23:37:52,496 [INFO]: Launching command detect-definitions
2021-07-26 23:37:52,513 [INFO]: Using base url: https://scholarphi.s3-us-west-1.amazonaws.com/
2021-07-26 23:37:57,445 [ERROR]: Unexpected exception processing papers: ['1601.00978v1']
Traceback (most recent call last):
  File "scripts/run_pipeline.py", line 89, in run_commands_for_arxiv_ids
    run_command(command)
  File "/data-processing/scripts/commands.py", line 98, in run_command
    for result in cmd.process(item):
  File "/data-processing/entities/definitions/commands/detect_definitions.py", line 608, in process
    model = DefinitionDetectionModel(prediction_types)
  File "/data-processing/entities/definitions/nlp.py", line 102, in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
  File "/usr/lib/python3.7/urllib/request.py", line 247, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.7/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
Traceback (most recent call last):
  File "scripts/run_pipeline.py", line 508, in <module>
    filtered_commands, [arxiv_id], args
  File "scripts/run_pipeline.py", line 95, in run_commands_for_arxiv_ids
    raise exc
  File "scripts/run_pipeline.py", line 89, in run_commands_for_arxiv_ids
    run_command(command)
  File "/data-processing/scripts/commands.py", line 98, in run_command
    for result in cmd.process(item):
  File "/data-processing/entities/definitions/commands/detect_definitions.py", line 608, in process
    model = DefinitionDetectionModel(prediction_types)
  File "/data-processing/entities/definitions/nlp.py", line 102, in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
  File "/usr/lib/python3.7/urllib/request.py", line 247, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.7/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
2021-07-26 23:37:57,451 [INFO]: Internal process exited
```
The 404 was encountered again, and we do not appear to have any output in most of the definitions output directories:
```
root@148f988860e5:/data-processing# ls data/30-sentence-tokens/1601.00978v1/
sentences.csv  tokens.csv
root@148f988860e5:/data-processing# ls data/31-annotation-files/1601.00978v1/
initial_annotations.ann  sentences_for_annotation.txt  tokens.csv
root@148f988860e5:/data-processing# ls data/32-detected-definitions/
root@148f988860e5:/data-processing# ls data/33-contexts-for-definitions/
root@148f988860e5:/data-processing# ls data/34-sources-with-colorized-definitions/
root@148f988860e5:/data-processing# ls data/35-compiled-sources-with-colorized-definitions/
root@148f988860e5:/data-processing# ls data/36-paper-images-with-colorized-definitions/
root@148f988860e5:/data-processing# ls data/37-diffed-images-with-colorized-definitions/
root@148f988860e5:/data-processing# ls data/38-definitions-locations/
root@148f988860e5:/data-processing# 
```
#### Providing an alternative location:
```
python scripts/run_pipeline.py --one-paper-at-a-time --arxiv-ids "1601.00978v1" --dry-run --entities definitions --definitions-base-url <alternative location> --keep-intermediate-files --keep-paper-data
...
2021-07-26 23:41:58,557 [INFO]: Launching command tokenize-sentences
2021-07-26 23:41:58,566 [WARNING]: Could not load child symbol SymbolId(tex_path='cratercnn.tex', equation_index=3, symbol_index=9) or parent symbol SymbolId(tex_path='cratercnn.tex', equation_index=3, symbol_index=4) for paper 1601.00978v1 when associating the two as parent and child. There may have been an error in the equation parser, like a failure to find tokens for the child symbol.
2021-07-26 23:42:00,187 [INFO]: Finished running command tokenize-sentences
2021-07-26 23:42:00,354 [INFO]: Launching command create-annotation-files
2021-07-26 23:42:00,504 [INFO]: Finished running command create-annotation-files
2021-07-26 23:42:00,504 [INFO]: Launching command detect-definitions
...
2021-07-26 23:44:59,187 [INFO]: Finished running command detect-definitions
2021-07-26 23:44:59,187 [INFO]: Launching command extract-contexts-for-definitions
2021-07-26 23:44:59,215 [INFO]: Finished running command extract-contexts-for-definitions
2021-07-26 23:44:59,216 [INFO]: Launching command locate-bounding-boxes-for-definitions
...
2021-07-26 23:45:11,076 [INFO]: Finished running command locate-bounding-boxes-for-definitions
2021-07-26 23:45:11,090 [WARNING]: Could not find citation locations for 1601.00978v1. Skipping
2021-07-26 23:45:11,092 [INFO]: Internal process exited
```
The 404 was not encountered again, and we do appear to have output in the definitions output directories:
```
root@bb84ab45adff:/data-processing# ls data/30-sentence-tokens/1601.00978v1/
sentences.csv  tokens.csv
root@bb84ab45adff:/data-processing# ls data/31-annotation-files/1601.00978v1/
initial_annotations.ann  sentences_for_annotation.txt  tokens.csv
root@bb84ab45adff:/data-processing# ls data/32-detected-definitions/1601.00978v1/
entities-definiendums.csv  entities-definitions.csv  entities-term-references.csv
root@bb84ab45adff:/data-processing# ls data/33-contexts-for-definitions/1601.00978v1/
contexts.csv
root@bb84ab45adff:/data-processing# ls data/34-sources-with-colorized-definitions/1601.00978v1/                          
cratercnn.tex-iteration-0-0  cratercnn.tex-iteration-0-1  cratercnn.tex-iteration-0-2  cratercnn.tex-iteration-0-3  cratercnn.tex-iteration-0-4  cratercnn.tex-iteration-0-5
root@bb84ab45adff:/data-processing# ls data/35-compiled-sources-with-colorized-definitions/1601.00978v1/
cratercnn.tex-iteration-0-0  cratercnn.tex-iteration-0-1  cratercnn.tex-iteration-0-2  cratercnn.tex-iteration-0-3  cratercnn.tex-iteration-0-4  cratercnn.tex-iteration-0-5
root@bb84ab45adff:/data-processing# ls data/36-paper-images-with-colorized-definitions/1601.00978v1/
cratercnn.tex-iteration-0-0  cratercnn.tex-iteration-0-1  cratercnn.tex-iteration-0-2  cratercnn.tex-iteration-0-3  cratercnn.tex-iteration-0-4  cratercnn.tex-iteration-0-5
root@bb84ab45adff:/data-processing# ls data/37-diffed-images-with-colorized-definitions/
1601.00978v1
root@bb84ab45adff:/data-processing# ls data/37-diffed-images-with-colorized-definitions/1601.00978v1/
cratercnn.tex-iteration-0-0  cratercnn.tex-iteration-0-1  cratercnn.tex-iteration-0-2  cratercnn.tex-iteration-0-3  cratercnn.tex-iteration-0-4  cratercnn.tex-iteration-0-5
root@bb84ab45adff:/data-processing# ls data/38-definitions-locations/1601.00978v1/
entity_locations.csv
```
#### Compare to running without the changes in this PR
```
python scripts/run_pipeline.py --one-paper-at-a-time --arxiv-ids "1601.00978v1" --dry-run --entities definitions  --keep-intermediate-files --keep-paper-data
...
2021-07-26 23:53:55,229 [INFO]: Launching command detect-definitions
2021-07-26 23:54:00,043 [ERROR]: Unexpected exception processing papers: ['1601.00978v1']
Traceback (most recent call last):
  File "scripts/run_pipeline.py", line 86, in run_commands_for_arxiv_ids
    run_command(command)
  File "/data-processing/scripts/commands.py", line 98, in run_command
    for result in cmd.process(item):
  File "/data-processing/entities/definitions/commands/detect_definitions.py", line 605, in process
    model = DefinitionDetectionModel(prediction_types)
  File "/data-processing/entities/definitions/nlp.py", line 96, in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
  File "/usr/lib/python3.7/urllib/request.py", line 247, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.7/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
Traceback (most recent call last):
  File "scripts/run_pipeline.py", line 500, in <module>
    filtered_commands, [arxiv_id], args
  File "scripts/run_pipeline.py", line 92, in run_commands_for_arxiv_ids
    raise exc
  File "scripts/run_pipeline.py", line 86, in run_commands_for_arxiv_ids
    run_command(command)
  File "/data-processing/scripts/commands.py", line 98, in run_command
    for result in cmd.process(item):
  File "/data-processing/entities/definitions/commands/detect_definitions.py", line 605, in process
    model = DefinitionDetectionModel(prediction_types)
  File "/data-processing/entities/definitions/nlp.py", line 96, in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
  File "/usr/lib/python3.7/urllib/request.py", line 247, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.7/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
2021-07-26 23:54:00,048 [INFO]: Internal process exited
```
Again the 404 is encountered, and most of the definition-related output directories have nothing in them:
```
root@30af6b8b7d21:/data-processing# ls data/39-sentence-tokens/1601.00978v1/
sentences.csv  tokens.csv
root@30af6b8b7d21:/data-processing# ls data/40-annotation-files/1601.00978v1/
initial_annotations.ann  sentences_for_annotation.txt  tokens.csv
root@30af6b8b7d21:/data-processing# ls data/41-detected-definitions/
root@30af6b8b7d21:/data-processing# ls data/42-contexts-for-definitions/
root@30af6b8b7d21:/data-processing# ls data/43-sources-with-colorized-definitions/
root@30af6b8b7d21:/data-processing# ls data/44-compiled-sources-with-colorized-definitions/
root@30af6b8b7d21:/data-processing# la data/45-paper-images-with-colorized-definitions/
root@30af6b8b7d21:/data-processing# ls data/46-diffed-images-with-colorized-definitions/
root@30af6b8b7d21:/data-processing# ls data/47-definitions-locations/
root@30af6b8b7d21:/data-processing# 
```

### Running the tests
(from scholarphi/data-processing)

#### Without the changes in this PR
```
# pytest --all
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.5, pytest-5.3.1, py-1.10.0, pluggy-0.13.1
rootdir: /data-processing, inifile: pytest.ini, testpaths: tests
plugins: cov-2.5.1
collected 202 items                                                                                                                                                                                                                          

tests/test_bounding_box.py ..................                                                                                                                                                                                          [  8%]
tests/test_colorize_sentences.py .....                                                                                                                                                                                                 [ 11%]
tests/test_colorize_tex.py ........                                                                                                                                                                                                    [ 15%]
tests/test_compile.py ........                                                                                                                                                                                                         [ 19%]
tests/test_extract_definitions.py E.E....E....E.EEEssss                                                                                                                                                                                [ 29%]
tests/test_locate_symbols.py ...                                                                                                                                                                                                       [ 31%]
tests/test_match_symbols.py ......                                                                                                                                                                                                     [ 34%]
tests/test_normalize_tex.py ..............                                                                                                                                                                                             [ 41%]
tests/test_parse_equation.py .........................                                                                                                                                                                                 [ 53%]
tests/test_parse_tex.py ..............................................                                                                                                                                                                 [ 76%]
tests/test_sanitize_equation.py ....                                                                                                                                                                                                   [ 78%]
tests/test_scan_tex.py .....                                                                                                                                                                                                           [ 80%]
tests/test_string.py .............                                                                                                                                                                                                     [ 87%]
tests/test_unpack.py ....                                                                                                                                                                                                              [ 89%]
tests/test_visual_validate.py ......                                                                                                                                                                                                   [ 92%]
tests/common/test_fetch_arxiv.py ......                                                                                                                                                                                                [ 95%]
tests/common/commands/test_fetch_arxiv_sources.py ..                                                                                                                                                                                   [ 96%]
tests/common/commands/test_fetch_s2_data.py ........                                                                                                                                                                                   [100%]

=================================================================================================================== ERRORS ===================================================================================================================
__________________________________________________________________________________________ ERROR at setup of test_model_extracts_simple_definitions __________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
________________________________________________________________________________________ ERROR at setup of test_model_extracts_nickname_before_symbol ________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
________________________________________________________________________________________ ERROR at setup of test_model_extracts_nickname_symbol_filter ________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
_________________________________________________________________________________________ ERROR at setup of test_model_extract_abbreviation_acronym __________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
____________________________________________________________________________________________ ERROR at setup of test_extract_abbreviation_acronym _____________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
______________________________________________________________________________________ ERROR at setup of test_model_extract_abbreviation_shortened_word ______________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
_________________________________________________________________________________________ ERROR at setup of test_extract_abbreviation_shortened_word _________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:96: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f16560aa890>, req = <urllib.request.Request object at 0x7f16560aaad0>, fp = <http.client.HTTPResponse object at 0x7f16560bb310>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f16560bb690>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
============================================================================================================== warnings summary ==============================================================================================================
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
  /usr/local/lib/python3.7/dist-packages/wandb/util.py:37: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import namedtuple, Mapping, Sequence

/usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55
  /usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    assert isinstance(locations, collections.Iterable), 'Must provide locations for directive.'

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
  /usr/local/lib/python3.7/dist-packages/catalogue.py:138: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
  /usr/local/lib/python3.7/dist-packages/catalogue.py:126: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================ 191 passed, 4 skipped, 7 warnings, 7 errors in 7.91s ============================================================================================
```
#### With the changes in this PR
```
pytest --all
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.5, pytest-5.3.1, py-1.10.0, pluggy-0.13.1
rootdir: /data-processing, inifile: pytest.ini, testpaths: tests
plugins: cov-2.5.1
collected 202 items                                                                                                                                                                                                                          

tests/test_bounding_box.py ..................                                                                                                                                                                                          [  8%]
tests/test_colorize_sentences.py .....                                                                                                                                                                                                 [ 11%]
tests/test_colorize_tex.py ........                                                                                                                                                                                                    [ 15%]
tests/test_compile.py ........                                                                                                                                                                                                         [ 19%]
tests/test_extract_definitions.py E.E....E....E.EEEssss                                                                                                                                                                                [ 29%]
tests/test_locate_symbols.py ...                                                                                                                                                                                                       [ 31%]
tests/test_match_symbols.py ......                                                                                                                                                                                                     [ 34%]
tests/test_normalize_tex.py ..............                                                                                                                                                                                             [ 41%]
tests/test_parse_equation.py .........................                                                                                                                                                                                 [ 53%]
tests/test_parse_tex.py ..............................................                                                                                                                                                                 [ 76%]
tests/test_sanitize_equation.py ....                                                                                                                                                                                                   [ 78%]
tests/test_scan_tex.py .....                                                                                                                                                                                                           [ 80%]
tests/test_string.py .............                                                                                                                                                                                                     [ 87%]
tests/test_unpack.py ....                                                                                                                                                                                                              [ 89%]
tests/test_visual_validate.py ......                                                                                                                                                                                                   [ 92%]
tests/common/test_fetch_arxiv.py ......                                                                                                                                                                                                [ 95%]
tests/common/commands/test_fetch_arxiv_sources.py ..                                                                                                                                                                                   [ 96%]
tests/common/commands/test_fetch_s2_data.py ........                                                                                                                                                                                   [100%]

=================================================================================================================== ERRORS ===================================================================================================================
__________________________________________________________________________________________ ERROR at setup of test_model_extracts_simple_definitions __________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
________________________________________________________________________________________ ERROR at setup of test_model_extracts_nickname_before_symbol ________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
________________________________________________________________________________________ ERROR at setup of test_model_extracts_nickname_symbol_filter ________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
_________________________________________________________________________________________ ERROR at setup of test_model_extract_abbreviation_acronym __________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
____________________________________________________________________________________________ ERROR at setup of test_extract_abbreviation_acronym _____________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
______________________________________________________________________________________ ERROR at setup of test_model_extract_abbreviation_shortened_word ______________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
_________________________________________________________________________________________ ERROR at setup of test_extract_abbreviation_shortened_word _________________________________________________________________________________________

    @pytest.fixture(scope="module")
    def model():
>       model = DefinitionDetectionModel(["AI2020", "DocDef2", "W00"])

tests/test_extract_definitions.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
entities/definitions/nlp.py:100: in __init__
    os.path.join("{}/{}".format(cache_directory, cache_file)),
/usr/lib/python3.7/urllib/request.py:247: in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
/usr/lib/python3.7/urllib/request.py:222: in urlopen
    return opener.open(url, data, timeout)
/usr/lib/python3.7/urllib/request.py:531: in open
    response = meth(req, response)
/usr/lib/python3.7/urllib/request.py:641: in http_response
    'http', request, response, code, msg, hdrs)
/usr/lib/python3.7/urllib/request.py:569: in error
    return self._call_chain(*args)
/usr/lib/python3.7/urllib/request.py:503: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f457ca8ad10>, req = <urllib.request.Request object at 0x7f457ca8aed0>, fp = <http.client.HTTPResponse object at 0x7f457ca91050>, code = 404, msg = 'Not Found'
hdrs = <http.client.HTTPMessage object at 0x7f457ca91150>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 404: Not Found

/usr/lib/python3.7/urllib/request.py:649: HTTPError
============================================================================================================== warnings summary ==============================================================================================================
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
  /usr/local/lib/python3.7/dist-packages/wandb/util.py:37: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import namedtuple, Mapping, Sequence

/usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55
  /usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    assert isinstance(locations, collections.Iterable), 'Must provide locations for directive.'

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
  /usr/local/lib/python3.7/dist-packages/catalogue.py:138: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
  /usr/local/lib/python3.7/dist-packages/catalogue.py:126: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================ 191 passed, 4 skipped, 7 warnings, 7 errors in 8.01s ============================================================================================
```
So in both the cases above, 7 errors occur, all to do with definitions and having trouble setting up, all encountering 404s. 

I tried hard-coding in the alternative location I have access to here: `tests/test_extract_definitions.py:16`. When I tried that, the tests all passed (apart from the ones that are getting skipped):
```
# pytest --all
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.5, pytest-5.3.1, py-1.10.0, pluggy-0.13.1
rootdir: /data-processing, inifile: pytest.ini, testpaths: tests
plugins: cov-2.5.1
collected 202 items                                                                                                                                                                                                                          

tests/test_bounding_box.py ..................                                                                                                                                                                                          [  8%]
tests/test_colorize_sentences.py .....                                                                                                                                                                                                 [ 11%]
tests/test_colorize_tex.py ........                                                                                                                                                                                                    [ 15%]
tests/test_compile.py ........                                                                                                                                                                                                         [ 19%]
tests/test_extract_definitions.py .................ssss                                                                                                                                                                                [ 29%]
tests/test_locate_symbols.py ...                                                                                                                                                                                                       [ 31%]
tests/test_match_symbols.py ......                                                                                                                                                                                                     [ 34%]
tests/test_normalize_tex.py ..............                                                                                                                                                                                             [ 41%]
tests/test_parse_equation.py .........................                                                                                                                                                                                 [ 53%]
tests/test_parse_tex.py ..............................................                                                                                                                                                                 [ 76%]
tests/test_sanitize_equation.py ....                                                                                                                                                                                                   [ 78%]
tests/test_scan_tex.py .....                                                                                                                                                                                                           [ 80%]
tests/test_string.py .............                                                                                                                                                                                                     [ 87%]
tests/test_unpack.py ....                                                                                                                                                                                                              [ 89%]
tests/test_visual_validate.py ......                                                                                                                                                                                                   [ 92%]
tests/common/test_fetch_arxiv.py ......                                                                                                                                                                                                [ 95%]
tests/common/commands/test_fetch_arxiv_sources.py ..                                                                                                                                                                                   [ 96%]
tests/common/commands/test_fetch_s2_data.py ........                                                                                                                                                                                   [100%]

============================================================================================================== warnings summary ==============================================================================================================
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
  /usr/local/lib/python3.7/dist-packages/wandb/util.py:37: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import namedtuple, Mapping, Sequence

/usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55
  /usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    assert isinstance(locations, collections.Iterable), 'Must provide locations for directive.'

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_nickname_before_symbol
tests/test_extract_definitions.py::test_model_extracts_nickname_before_symbol
tests/test_extract_definitions.py::test_model_extracts_nickname_symbol_filter
tests/test_extract_definitions.py::test_model_extracts_nickname_symbol_filter
tests/test_extract_definitions.py::test_model_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_model_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_model_extract_abbreviation_shortened_word
tests/test_extract_definitions.py::test_model_extract_abbreviation_shortened_word
tests/test_extract_definitions.py::test_extract_abbreviation_shortened_word
tests/test_extract_definitions.py::test_extract_abbreviation_shortened_word
  /usr/local/lib/python3.7/dist-packages/catalogue.py:138: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
  /usr/local/lib/python3.7/dist-packages/catalogue.py:126: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================== 198 passed, 4 skipped, 21 warnings in 167.27s (0:02:47) ===========================================================================================
```
So basically, I think these tests will fail for anyone who does not have access to the default definitions location.