### PR TITLE
Run with prod settings in the deployed environment.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -157,6 +157,7 @@ function(
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
+                            args: [ 'start.py', '--prod' ],
                             readinessProbe: {
                                 httpGet: {
                                     port: apiPort,


### PR DESCRIPTION
So that logs are formatted as JSON.