### PR TITLE
Add preset for papers for 2021 SAB paper review

### DIFF
--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -117,10 +117,12 @@ const PRESETS: Preset[] = [
   {
     key: "demo",
     primerInstructionsEnabled: false,
-    useDefinitionsForDiagramLabels: true,
+    // useDefinitionsForDiagramLabels: true,
     termGlossesEnabled: true,
     declutterEnabled: true,
     equationDiagramsEnabled: true,
+    symbolUnderlineMethod: "defined-symbols",
+    definitionsInSymbolGloss: true
   },
   {
     key: "sab",

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -117,10 +117,16 @@ const PRESETS: Preset[] = [
   {
     key: "demo",
     primerInstructionsEnabled: false,
-    // useDefinitionsForDiagramLabels: true,
+    useDefinitionsForDiagramLabels: true,
     termGlossesEnabled: true,
     declutterEnabled: true,
     equationDiagramsEnabled: true,
+  },
+  {
+    key: "sab-2021",
+    primerInstructionsEnabled: false,
+    termGlossesEnabled: true,
+    declutterEnabled: true,
     symbolUnderlineMethod: "defined-symbols",
     definitionsInSymbolGloss: true
   },

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -111,9 +111,14 @@ interface Preset extends Partial<Settings> {
 }
 
 /**
- * Define new presets for settings here.
+ * Define new presets for settings here. The user interface can be loaded with a
+ * preset by using "&preset=<key>" as a query parameter, with the available keys
+ * defined in the 'key' properties of each preset below.
  */
 const PRESETS: Preset[] = [
+  /*
+   * ScholarPhi public demo circa September 2020.
+   */
   {
     key: "demo",
     primerInstructionsEnabled: false,
@@ -122,6 +127,10 @@ const PRESETS: Preset[] = [
     declutterEnabled: true,
     equationDiagramsEnabled: true,
   },
+  /*
+   * Demo for the AI2 Scientific Adivsory board readings in September 2021.
+   * Experimental definitions of symbols and abbreviations are shown, but not equation diagrams.
+   */
   {
     key: "sab-2021",
     primerInstructionsEnabled: false,
@@ -130,6 +139,9 @@ const PRESETS: Preset[] = [
     symbolUnderlineMethod: "defined-symbols",
     definitionsInSymbolGloss: true
   },
+  /*
+   * Demo for AI2 Scientific Advisory board readings in September 2020.
+   */
   {
     key: "sab",
     termGlossesEnabled: false,
@@ -137,6 +149,10 @@ const PRESETS: Preset[] = [
     symbolUnderlineMethod: "defined-symbols",
     primerInstructionsEnabled: true,
   },
+  /*
+   * Demo for AI2 Scientific Advisory board readings in September 2020.
+   * "Light" configuration with symbol definitions and equation diagrams turned off.
+  */
   {
     key: "sab-lite",
     symbolUnderlineMethod: "top-level-symbols",


### PR DESCRIPTION
This PR adds a new preset to the deployed Semantic Reader UI. When deployed, this will let readers to append the `&preset=sab-2021` parameter to access symbol and abbreviation definition functionality.

None of the underlying functionality of the app is changed. The main purpose of this PR is to provide the Allen AI a switch for the Scientific Advisory board to preview experimental ML features, without turning them on for all readers of Semantic Reader.