### PR TITLE
Fetch arxiv pdf script

### DIFF
--- a/data-processing/scripts/fetch_arxiv_pdf.py
+++ b/data-processing/scripts/fetch_arxiv_pdf.py
@@ -1,0 +1,38 @@
+import argparse
+import os
+
+from common import directories
+from common.fetch_arxiv import fetch_pdf_from_arxiv
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        "Fetch a single arXiv pdf."
+    )
+    parser.add_argument(
+        "arxiv_id",
+        help="The arXiv ID for a paper. May include version number (i.e., 'v1', 'v2', etc.)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help=(
+            "Directory into which the pdf will be fetched. The fetched pdf"
+            + "will be saved in the output folder as <arxiv_id>.pdf"
+        ),
+        default="tmp",
+    )
+
+    args = parser.parse_args()
+    arxiv_id = args.arxiv_id
+
+    output_dir = args.output_dir
+    pdf_path = os.path.join(output_dir, f"{directories.escape_slashes(arxiv_id)}.pdf")
+
+    if not os.path.exists(output_dir):
+        print(f"Creating directory to hold pdf at {output_dir}.")
+        os.makedirs(output_dir)
+
+    print(f"Downloading pdf from arXiv for paper {arxiv_id}...")
+
+    fetch_pdf_from_arxiv(arxiv_id, dest=pdf_path)
+    print("done.")


### PR DESCRIPTION
Related to https://github.com/allenai/scholar/issues/29343. 

This PR adds a script making it easy to run the existing `fetch_pdf_from_arxiv` function. The script follows the pattern of the existing [fetch_arxiv_sources.py](https://github.com/allenai/scholarphi/blob/main/data-processing/scripts/fetch_arxiv_sources.py) script.

The idea is for scholarphi-pipeline to use the existing `fetch_pdf_from_arxiv` function to get pdfs, so that it can save any pdfs we don't already have to S3, so that we can then associate annotations with them in the annotation store (which for pdf annotations expects that the pdf is in a S3 location it can access). 

Testing done:
I ran pytest:
```
# pytest
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.5, pytest-5.3.1, py-1.10.0, pluggy-0.13.1
rootdir: /data-processing, inifile: pytest.ini, testpaths: tests
plugins: cov-2.5.1
collected 202 items                                                                                                                                                                                                                          

tests/test_bounding_box.py ..................                                                                                                                                                                                          [  8%]
tests/test_colorize_sentences.py .....                                                                                                                                                                                                 [ 11%]
tests/test_colorize_tex.py ........                                                                                                                                                                                                    [ 15%]
tests/test_compile.py ........                                                                                                                                                                                                         [ 19%]
tests/test_extract_definitions.py ssss...ss...sssssssss                                                                                                                                                                                [ 29%]
tests/test_locate_symbols.py ...                                                                                                                                                                                                       [ 31%]
tests/test_match_symbols.py ......                                                                                                                                                                                                     [ 34%]
tests/test_normalize_tex.py ..............                                                                                                                                                                                             [ 41%]
tests/test_parse_equation.py .........................                                                                                                                                                                                 [ 53%]
tests/test_parse_tex.py ..............................................                                                                                                                                                                 [ 76%]
tests/test_sanitize_equation.py ....                                                                                                                                                                                                   [ 78%]
tests/test_scan_tex.py .....                                                                                                                                                                                                           [ 80%]
tests/test_string.py .............                                                                                                                                                                                                     [ 87%]
tests/test_unpack.py ....                                                                                                                                                                                                              [ 89%]
tests/test_visual_validate.py ......                                                                                                                                                                                                   [ 92%]
tests/common/test_fetch_arxiv.py ......                                                                                                                                                                                                [ 95%]
tests/common/commands/test_fetch_arxiv_sources.py ..                                                                                                                                                                                   [ 96%]
tests/common/commands/test_fetch_s2_data.py ........                                                                                                                                                                                   [100%]

============================================================================================================== warnings summary ==============================================================================================================
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
  /usr/local/lib/python3.7/dist-packages/wandb/util.py:37: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import namedtuple, Mapping, Sequence

/usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55
  /usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    assert isinstance(locations, collections.Iterable), 'Must provide locations for directive.'

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================ 187 passed, 15 skipped, 3 warnings in 5.97s =================================================================================================
```
I ran the new script:
```
# python scripts/fetch_arxiv_pdf.py 1601.00978v1 --output-dir hi
Creating directory to hold pdf at hi.
Downloading pdf from arXiv for paper 1601.00978v1...
done.
root@1b8c65cbed16:/data-processing# ls hi
1601.00978v1.pdf
```
And opened the relevant file. It looked like a paper pdf.

Note: I think I expect that most arXiv pdfs would be in our pdf bucket already, but we still need to pull the pdf to get the content hash to figure out if the pdf is already there.

Note: This PR is for merging into the chi-2021-demo branch, as that is the code that scholarphi-pipeline is currently running.