### PR TITLE
json instead of jsonl for output file name

### DIFF
--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -129,7 +129,7 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
             entity_infos=entity_infos,
             data_version=self.args.data_version,
             output_details=self.output_details,
-            filename="citations.jsonl",
+            filename="citations.json",
         )
 
     def can_write_to_file(self) -> bool:

--- a/data-processing/tests/common/test_upload_entities.py
+++ b/data-processing/tests/common/test_upload_entities.py
@@ -16,7 +16,7 @@ def test_save_entities_with_file():
                 entity_infos=[],
                 data_version=None,
                 output_details=output_details,
-                filename="something.jsonl"
+                filename="something.json"
             )
 
             assert not mock_upload_entities.called
@@ -34,7 +34,7 @@ def test_save_entities_with_db():
                 entity_infos=[],
                 data_version=None,
                 output_details=output_details,
-                filename="something.jsonl"
+                filename="something.json"
             )
 
             assert mock_upload_entities.called
@@ -52,7 +52,7 @@ def test_save_entities_with_both():
                 entity_infos=[],
                 data_version=None,
                 output_details=output_details,
-                filename="something.jsonl"
+                filename="something.json"
             )
 
             assert mock_upload_entities.called


### PR DESCRIPTION
Addressing the comment [here](https://github.com/allenai/scholarphi/pull/318#issuecomment-926733871). Basically, when we write output to a given file via the `--output-forms file` option, the output is written as one json object, so `.json` fits better than `.jsonl`.

Thanks for pointing this out @andrewhead !

Testing done:

Ran the tests:
```
pytest --all
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.5, pytest-5.3.1, py-1.10.0, pluggy-0.13.1
rootdir: /data-processing, inifile: pytest.ini, testpaths: tests
plugins: cov-2.5.1
collected 214 items                                                                                                                                                                                                                          

tests/test_bounding_box.py ..................                                                                                                                                                                                          [  8%]
tests/test_colorize_sentences.py .....                                                                                                                                                                                                 [ 10%]
tests/test_colorize_tex.py ........                                                                                                                                                                                                    [ 14%]
tests/test_compile.py ........                                                                                                                                                                                                         [ 18%]
tests/test_extract_definitions.py .................ssss                                                                                                                                                                                [ 28%]
tests/test_locate_symbols.py ...                                                                                                                                                                                                       [ 29%]
tests/test_match_symbols.py ......                                                                                                                                                                                                     [ 32%]
tests/test_normalize_tex.py ..............                                                                                                                                                                                             [ 38%]
tests/test_parse_equation.py .........................                                                                                                                                                                                 [ 50%]
tests/test_parse_tex.py ..............................................                                                                                                                                                                 [ 71%]
tests/test_sanitize_equation.py ....                                                                                                                                                                                                   [ 73%]
tests/test_scan_tex.py .....                                                                                                                                                                                                           [ 76%]
tests/test_string.py .............                                                                                                                                                                                                     [ 82%]
tests/test_unpack.py ....                                                                                                                                                                                                              [ 84%]
tests/test_visual_validate.py ......                                                                                                                                                                                                   [ 86%]
tests/common/test_fetch_arxiv.py ......                                                                                                                                                                                                [ 89%]
tests/common/test_upload_entities.py ............                                                                                                                                                                                      [ 95%]
tests/common/commands/test_fetch_arxiv_sources.py ..                                                                                                                                                                                   [ 96%]
tests/common/commands/test_fetch_s2_data.py ........                                                                                                                                                                                   [100%]

============================================================================================================== warnings summary ==============================================================================================================
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
/usr/local/lib/python3.7/dist-packages/wandb/util.py:37
  /usr/local/lib/python3.7/dist-packages/wandb/util.py:37: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import namedtuple, Mapping, Sequence

/usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55
  /usr/local/lib/python3.7/dist-packages/wandb/vendor/graphql-core-1.1/graphql/type/directives.py:55: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    assert isinstance(locations, collections.Iterable), 'Must provide locations for directive.'

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_simple_definitions
tests/test_extract_definitions.py::test_model_extracts_nickname_before_symbol
tests/test_extract_definitions.py::test_model_extracts_nickname_before_symbol
tests/test_extract_definitions.py::test_model_extracts_nickname_symbol_filter
tests/test_extract_definitions.py::test_model_extracts_nickname_symbol_filter
tests/test_extract_definitions.py::test_model_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_model_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_extract_abbreviation_acronym
tests/test_extract_definitions.py::test_model_extract_abbreviation_shortened_word
tests/test_extract_definitions.py::test_model_extract_abbreviation_shortened_word
tests/test_extract_definitions.py::test_extract_abbreviation_shortened_word
tests/test_extract_definitions.py::test_extract_abbreviation_shortened_word
  /usr/local/lib/python3.7/dist-packages/catalogue.py:138: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

tests/test_extract_definitions.py::test_model_extracts_simple_definitions
  /usr/local/lib/python3.7/dist-packages/catalogue.py:126: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================== 210 passed, 4 skipped, 21 warnings in 166.42s (0:02:46) ===========================================================================================
```
Tried writing to a file:
```
python scripts/run_pipeline.py --one-paper-at-a-time --arxiv-ids "1601.00978v1" --output-forms file --output-dir hi --entities citations
wandb: WARNING W&B installed but not logged in.  Run `wandb login` or set the WANDB_API_KEY env variable.
2021-09-24 17:50:13,112 [INFO]: Running pipeline for paper 1601.00978v1
2021-09-24 17:50:13,112 [INFO]: Launching command fetch-arxiv-sources
...
2021-09-24 17:50:32,856 [INFO]: Finished running command locate-citations
2021-09-24 17:50:32,856 [INFO]: We will be writing output to files.
2021-09-24 17:50:32,856 [INFO]: Launching command upload-citations
2021-09-24 17:50:32,858 [INFO]: Saving to file...
2021-09-24 17:50:32,858 [INFO]: About to write 9 entity infos to hi/citations.json (version: v0).
2021-09-24 17:50:32,859 [INFO]: Finished running command upload-citations
2021-09-24 17:50:32,867 [INFO]: Internal process exited
root@22a8461d5e02:/data-processing# ls hi
citations.json
root@22a8461d5e02:/data-processing# cat hi/citations.json 
{"format_version": "v0", "data": [{"id_": "bandeira_automatic_2010-0", "type_": "citation", "bounding_boxes": [{"left": 0.47549019607843135, "top": 0.30808080808080807, "width": 0.0016339869281045752, "height": 0.008838383838383838, "page": 0, "tex_path": "N/A", "entity_id": "bandeira_automatic_2010-0"}], "data": {"key": "bandeira_automatic_2010", "paper_id": "9769ac9d79a75cfefd3731978b9f319d68345ab5"}, "relationships": null}, {"id_": "bandeira_automatic_2010-1", "type_": "citation", "bounding_boxes": [{"left": 0.4035947712418301, "top": 0.3686868686868687, "width": 0.0016339869281045752, "height": 0.008838383838383838, "page": 0, "tex_path": "N/A", "entity_id": "bandeira_automatic_2010-1"}], "data": {"key": "bandeira_automatic_2010", "paper_id": "9769ac9d79a75cfefd3731978b9f319d68345ab5"}, "relationships": null}, {"id_": "bandeira_automatic_2010-2", "type_": "citation", "bounding_boxes": [{"left": 0.8137254901960784, "top": 0.5404040404040404, "width": 0.0016339869281045752, "height": 0.008838383838383838, "page": 1, "tex_path": "N/A", "entity_id": "bandeira_automatic_2010-2"}], "data": {"key": "bandeira_automatic_2010", "paper_id": "9769ac9d79a75cfefd3731978b9f319d68345ab5"}, "relationships": null}, {"id_": "bandeira_automatic_2010-3", "type_": "citation", "bounding_boxes": [{"left": 0.25326797385620914, "top": 0.5896464646464646, "width": 0.0016339869281045752, "height": 0.008838383838383838, "page": 1, "tex_path": "N/A", "entity_id": "bandeira_automatic_2010-3"}], "data": {"key": "bandeira_automatic_2010", "paper_id": "9769ac9d79a75cfefd3731978b9f319d68345ab5"}, "relationships": null}, {"id_": "urbach_automatic_2009-0", "type_": "citation", "bounding_boxes": [{"left": 0.2957516339869281, "top": 0.3686868686868687, "width": 0.004901960784313725, "height": 0.008838383838383838, "page": 0, "tex_path": "N/A", "entity_id": "urbach_automatic_2009-0"}], "data": {"key": "urbach_automatic_2009", "paper_id": "b4caa57f2321298073d651e95507052ccf2ed66d"}, "relationships": null}, {"id_": "urbach_automatic_2009-1", "type_": "citation", "bounding_boxes": [{"left": 0.23202614379084968, "top": 0.6944444444444444, "width": 0.004901960784313725, "height": 0.008838383838383838, "page": 1, "tex_path": "N/A", "entity_id": "urbach_automatic_2009-1"}], "data": {"key": "urbach_automatic_2009", "paper_id": "b4caa57f2321298073d651e95507052ccf2ed66d"}, "relationships": null}, {"id_": "ding_sub-kilometer_2011-0", "type_": "citation", "bounding_boxes": [{"left": 0.4166666666666667, "top": 0.3686868686868687, "width": 0.006535947712418301, "height": 0.008838383838383838, "page": 0, "tex_path": "N/A", "entity_id": "ding_sub-kilometer_2011-0"}], "data": {"key": "ding_sub-kilometer_2011", "paper_id": "447369e1c509e7e552220fa00eec93e474e1167b"}, "relationships": null}, {"id_": "krizhevsky_imagenet_2012-0", "type_": "citation", "bounding_boxes": [{"left": 0.16830065359477125, "top": 0.5202020202020202, "width": 0.006535947712418301, "height": 0.008838383838383838, "page": 0, "tex_path": "N/A", "entity_id": "krizhevsky_imagenet_2012-0"}], "data": {"key": "krizhevsky_imagenet_2012", "paper_id": "abd1c342495432171beb7ca8fd9551ef13cbd0ff"}, "relationships": null}, {"id_": "krizhevsky_imagenet_2012-1", "type_": "citation", "bounding_boxes": [{"left": 0.1568627450980392, "top": 0.38257575757575757, "width": 0.006535947712418301, "height": 0.008838383838383838, "page": 1, "tex_path": "N/A", "entity_id": "krizhevsky_imagenet_2012-1"}], "data": {"key": "krizhevsky_imagenet_2012", "paper_id": "abd1c342495432171beb7ca8fd9551ef13cbd0ff"}, "relationships": null}]}root@22a8461d5e02:/data-processing# python scripts/run_pipeline.py --one-paper-at-a-time --arxiv-ids "1601.00978v1" --output-forms file --output-dir hi --entities equations
```

Note: When we bump the image for scholarphi-pipeline, we should also adjust the code to look for `.json` files instead of `.jsonl` files.