### PR TITLE
UI: Position tooltip for sentence right beneath click location

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -12,7 +12,6 @@ import {
   isTerm,
   Paper,
   RhetoricUnit,
-  SentenceUnit,
   Symbol,
 } from "./api/types";
 import Control from "./components/control/Control";
@@ -132,6 +131,10 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
       skimOpacity: 0.3,
       showSkimmingAnnotations: true,
 
+      leadSentences:
+        props.paperId !== undefined
+          ? Object(sentenceData)[props.paperId.id]
+          : [],
       currentDiscourseObjId: null,
       discourseObjs: [],
       discourseObjsById: {},
@@ -594,6 +597,10 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
       drawerMode: "open",
       drawerContentType,
     });
+  };
+
+  openDrawerWithFacets = () => {
+    this.openDrawer("facets");
   };
 
   closeDrawer = (): void => {
@@ -1281,12 +1288,9 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
       this._jumpedToInitialFocus = true;
     }
 
-    let leadSentences: SentenceUnit[] = [];
-    if (this.props.paperId !== undefined) {
-      if (this.state.leadSentencesEnabled) {
-        leadSentences = Object(sentenceData)[this.props.paperId!.id];
-      }
-    }
+    const leadSentences = this.state.leadSentencesEnabled
+      ? this.state.leadSentences
+      : null;
 
     return (
       <>
@@ -1710,17 +1714,15 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                     {this.props.paperId !== undefined &&
                       this.state.showSkimmingAnnotations &&
                       (this.state.discourseObjs.length > 0 ||
-                        leadSentences.length > 0) &&
+                        (leadSentences !== null && leadSentences.length > 0)) &&
                       this.state.cueingStyle === "highlight" && (
                         <HighlightLayer
                           pageView={pageView}
                           discourseObjs={this.state.discourseObjs}
                           leadSentences={leadSentences}
                           opacity={this.state.skimOpacity}
-                          handleHideDiscourseObj={(d) =>
-                            this.handleHideDiscourseObj(d)
-                          }
-                          handleOpenDrawer={() => this.openDrawer("facets")}
+                          handleHideDiscourseObj={this.handleHideDiscourseObj}
+                          handleOpenDrawer={this.openDrawerWithFacets}
                           drawerOpen={
                             this.state.drawerMode === "open" &&
                             this.state.drawerContentType === "facets"
@@ -1731,7 +1733,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                     {this.props.paperId !== undefined &&
                       this.state.showSkimmingAnnotations &&
                       (this.state.discourseObjs.length > 0 ||
-                        leadSentences.length > 0) &&
+                        (leadSentences !== null && leadSentences.length > 0)) &&
                       this.state.cueingStyle === "underline" && (
                         <UnderlineLayer
                           pageView={pageView}

--- a/ui/src/components/discourse/DiscourseControlToolbar.tsx
+++ b/ui/src/components/discourse/DiscourseControlToolbar.tsx
@@ -4,13 +4,10 @@ import Close from "@material-ui/icons/Close";
 import DeleteIcon from "@material-ui/icons/Delete";
 import Toc from "@material-ui/icons/Toc";
 import { default as React } from "react";
-import { BoundingBox } from "../../api/types";
-import { PDFPageView } from "../../types/pdfjs-viewer";
-import * as uiUtils from "../../utils/ui";
 
 interface Props {
-  pageView: PDFPageView;
-  anchor: BoundingBox;
+  x: number;
+  y: number;
   handleClose: () => void;
   handleDeleteHighlight: () => void;
   handleOpenDrawer: () => void;
@@ -18,16 +15,15 @@ interface Props {
 
 class DiscourseControlToolbar extends React.PureComponent<Props> {
   render() {
-    const { pageView, anchor } = this.props;
-
-    const anchorPosition = uiUtils.getPositionInPageView(pageView, anchor);
+    const { x, y } = this.props;
 
     return (
       <div
         className="discourse-control-toolbar side-right"
         style={{
-          top: anchorPosition.top,
-          left: anchorPosition.left + anchorPosition.width + 10,
+          top: y,
+          left: x,
+          transform: "translate(-50%, 0)",
         }}
       >
         <table>

--- a/ui/src/components/discourse/UnderlineLayer.tsx
+++ b/ui/src/components/discourse/UnderlineLayer.tsx
@@ -6,7 +6,7 @@ import Annotation from "../entity/Annotation";
 interface Props {
   pageView: PDFPageView;
   discourseObjs: DiscourseObj[];
-  leadSentences: SentenceUnit[];
+  leadSentences: SentenceUnit[] | null;
 }
 
 class UnderlineLayer extends React.Component<Props> {
@@ -33,20 +33,21 @@ class UnderlineLayer extends React.Component<Props> {
             handleSelect={() => {}}
           />
         ))}
-        {leadSentences.map((x: SentenceUnit, index: number) => (
-          <Annotation
-            pageView={pageView}
-            key={index.toString()}
-            id={index.toString()}
-            className={"discourse-underline"}
-            underline={true}
-            active={false}
-            selected={false}
-            color={"#b3b300"}
-            boundingBoxes={x.bboxes}
-            handleSelect={() => {}}
-          />
-        ))}
+        {leadSentences !== null &&
+          leadSentences.map((x: SentenceUnit, index: number) => (
+            <Annotation
+              pageView={pageView}
+              key={index.toString()}
+              id={index.toString()}
+              className={"discourse-underline"}
+              underline={true}
+              active={false}
+              selected={false}
+              color={"#b3b300"}
+              boundingBoxes={x.bboxes}
+              handleSelect={() => {}}
+            />
+          ))}
       </div>
     );
   }

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -1,16 +1,15 @@
-import { SnackbarMode } from "./components/overlay/AppOverlay";
-import { DrawerContentType, DrawerMode } from "./components/drawer/Drawer";
+import { PDFDocumentProxy } from "pdfjs-dist/types/display/api";
+import { BoundingBox, DiscourseObj, Entity, Paper } from "./api/types";
 import { AreaSelectionMethod } from "./components/control/EntityCreationToolbar";
+import { DrawerContentType, DrawerMode } from "./components/drawer/Drawer";
+import { SnackbarMode } from "./components/overlay/AppOverlay";
 import { FindMode, FindQuery, SymbolFilter } from "./components/search/FindBar";
 import { Settings } from "./settings";
-import { Entity, Paper, DiscourseObj } from "./api/types";
 import {
   PDFPageView,
   PDFViewer,
   PDFViewerApplication,
 } from "./types/pdfjs-viewer";
-
-import { PDFDocumentProxy } from "pdfjs-dist/types/display/api";
 
 /**
  * An object containing all the shared global state. It is designed to be used as follows:
@@ -153,6 +152,7 @@ export interface State extends Settings {
   skimOpacity: number;
   showSkimmingAnnotations: boolean;
   currentDiscourseObjId: string | null;
+  leadSentences: { text: string; bboxes: BoundingBox[] }[];
   discourseObjs: DiscourseObj[];
   discourseObjsById: { [id: string]: DiscourseObj };
   deselectedDiscourses: string[];


### PR DESCRIPTION
In this PR, the position of the tooltip is set dynamically to be centered below the click position, right beneath the line that has been clicked.

This PR also contributes an adjustment to the tooltip show / hide behavior. In particular, updating the position of the tooltip even if the reader clicks in a different position in the sentence, and automatically dismissing the tooltip if a user clicks anywhere on a page outside of a sentence.

Some changes were made to `ScholarReader.tsx` and `state.ts` to allow the toolbar to render only once with each click event, by lightly editing the code so that a the HighlightLayer is not passed a new empty list of lead sentences every time that ScholarReader is re-rendered.

![scim-tooltip-position](https://user-images.githubusercontent.com/2358524/134904041-34a10bb9-d27b-4592-bed0-73d1406f4306.gif)
