### PR TITLE
UI: Add light border and shadow to tooltip to visually separate it from the text

### DIFF
--- a/ui/src/style/discourse-tag.less
+++ b/ui/src/style/discourse-tag.less
@@ -68,6 +68,8 @@
   padding: 4px;
   width: fit-content;
   background-color: whitesmoke;
+  box-shadow: 2px 2px 4px gray;
+  border: 0.5px #cccccc solid;
   border-radius: 10px;
 
   &:hover {


### PR DESCRIPTION
The tooltip previously appeared as follows. Due to its light color, it sometimes visually merged into the page behind it:

![image](https://user-images.githubusercontent.com/2358524/135281751-9854a3f1-1ffb-4f9f-951f-b8e473608905.png)

After this style change, the tooltip appears as follows. The color remains the same, though a border and shadow "pops" the tooltip off the page, making it easier to distinguish from the page it appears on.

![image](https://user-images.githubusercontent.com/2358524/135281740-c1cdcfae-8b69-47a0-9d3f-0e317bfb568a.png)