### PR TITLE
Fine-tune the behavior and appearance of discourse tag buttons

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -940,19 +940,22 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
   };
 
   selectDiscourseClass = (discourse: string) => {
-    if (this.state.deselectedDiscourses.includes(discourse)) {
-      if (this.state.numHighlightMultiplier[discourse] === 0) {
-        return;
+    this.setState((prevState) => {
+      if (prevState.deselectedDiscourses.includes(discourse)) {
+        if (prevState.numHighlightMultiplier[discourse] === 0) {
+          return prevState;
+        }
+        const tagRemoved = prevState.deselectedDiscourses.filter(
+          (d) => d !== discourse
+        );
+        return { ...prevState, deselectedDiscourses: tagRemoved };
+      } else {
+        return {
+          ...prevState,
+          deselectedDiscourses: [...prevState.deselectedDiscourses, discourse],
+        };
       }
-      const deselectedDiscourses = this.state.deselectedDiscourses.filter(
-        (x) => x !== discourse
-      );
-      this.setState({ deselectedDiscourses });
-    } else {
-      this.setState((prevState) => ({
-        deselectedDiscourses: [...prevState.deselectedDiscourses, discourse],
-      }));
-    }
+    });
   };
 
   filterToDiscourse = (discourse: string) => {

--- a/ui/src/components/discourse/DiscoursePalette.tsx
+++ b/ui/src/components/discourse/DiscoursePalette.tsx
@@ -1,7 +1,6 @@
-import Chip from "@material-ui/core/Chip";
-import classNames from "classnames";
 import React from "react";
 import { DiscourseObj } from "../../api/types";
+import DiscourseTagChip from "./DiscourseTagChip";
 
 interface Props {
   discourseToColorMap: { [discourse: string]: string };
@@ -10,49 +9,95 @@ interface Props {
   handleDiscourseSelected: (discourse: string) => void;
 }
 
+const TAG_DISPLAY_NAMES: { [key: string]: string } = {
+  Objective: "Objectives",
+  Novelty: "Novelty Statements",
+  Method: "Methods",
+};
 class DiscoursePalette extends React.PureComponent<Props> {
   constructor(props: Props) {
     super(props);
   }
 
-  render() {
+  onClickEverything = () => {
+    const { deselectedDiscourses } = this.props;
+    const allTags = this.getAvailableDiscourseTags();
+    /**
+     * If every tag is already selected, then deselect every tag.
+     */
+    if (deselectedDiscourses.length === 0) {
+      for (const clazz of allTags) {
+        this.props.handleDiscourseSelected(clazz);
+      }
+    } else {
+      /**
+       * Otherwise, select all unselected tags.
+       */
+      for (const clazz of allTags) {
+        if (deselectedDiscourses.indexOf(clazz) !== -1) {
+          this.props.handleDiscourseSelected(clazz);
+        }
+      }
+    }
+  };
+
+  getAvailableDiscourseTags = () => {
     const {
       discourseToColorMap,
       discourseObjs,
       deselectedDiscourses,
     } = this.props;
-
-    const availableDiscourseClasses = [
+    const selectedDiscourseClasses = [
       ...new Set(discourseObjs.map((x: DiscourseObj) => x.label)),
     ];
-    const filteredDiscourseToColorMap = Object.keys(discourseToColorMap)
+    const hidden = ["Highlight", "Author"];
+    return Object.keys(discourseToColorMap)
+      .filter((key) => !hidden.includes(key))
       .filter(
         (key) =>
-          availableDiscourseClasses.includes(key) ||
+          selectedDiscourseClasses.includes(key) ||
           deselectedDiscourses.includes(key)
-      )
-      .reduce((obj: { [label: string]: string }, key) => {
+      );
+  };
+
+  render() {
+    const { discourseToColorMap, deselectedDiscourses } = this.props;
+
+    const filteredDiscourseToColorMap = this.getAvailableDiscourseTags().reduce(
+      (obj: { [label: string]: string }, key) => {
         obj[key] = discourseToColorMap[key];
         return obj;
-      }, {});
+      },
+      {}
+    );
 
     return (
-      <div className={"discourse-chip-palette-wrapper"}>
-        <div className={"discourse-chip-palette"}>
-          {Object.entries(filteredDiscourseToColorMap).map(([d, color]) => {
-            return (
-              <Chip
-                className={classNames("discourse-chip", {
-                  deselected: deselectedDiscourses.includes(d),
-                })}
-                label={<span className={"discourse-chip-label"}>{d}</span>}
-                key={d}
-                onClick={() => this.props.handleDiscourseSelected(d)}
-                style={{ backgroundColor: color }}
-                variant="outlined"
-              />
-            );
-          })}
+      <div className="discourse-chip-palette-wrapper">
+        <p className="discourse-palette-header">Show me...</p>
+        <div className="discourse-chip-palette">
+          <div className="discourse-chip-palette__tags">
+            {Object.entries(filteredDiscourseToColorMap).map(([d, color]) => {
+              return (
+                <DiscourseTagChip
+                  id={d}
+                  name={TAG_DISPLAY_NAMES[d] || d}
+                  selected={!deselectedDiscourses.includes(d)}
+                  color={color}
+                  handleSelection={this.props.handleDiscourseSelected}
+                />
+              );
+            })}
+          </div>
+          <div className="discourse-chip-palette__everything">
+            <DiscourseTagChip
+              id="everything"
+              className="everything-chip"
+              name={"Everything"}
+              selected={deselectedDiscourses.length === 0}
+              color={"lightgray"}
+              handleSelection={this.onClickEverything}
+            />
+          </div>
         </div>
       </div>
     );

--- a/ui/src/components/discourse/DiscoursePalette.tsx
+++ b/ui/src/components/discourse/DiscoursePalette.tsx
@@ -9,18 +9,48 @@ interface Props {
   handleDiscourseSelected: (discourse: string) => void;
 }
 
+interface State {
+  firstSelection: boolean;
+}
+
 const TAG_DISPLAY_NAMES: { [key: string]: string } = {
   Objective: "Objectives",
   Novelty: "Novelty Statements",
   Method: "Methods",
 };
-class DiscoursePalette extends React.PureComponent<Props> {
+class DiscoursePalette extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
+    this.state = {
+      firstSelection: true,
+    };
   }
+
+  onClickTag = (tag: string) => {
+    if (this.state.firstSelection) {
+      for (const otherTag of this.getAvailableDiscourseTags()) {
+        if (otherTag !== tag) {
+          this.props.handleDiscourseSelected(otherTag);
+        }
+      }
+      this.setState({
+        firstSelection: false,
+      });
+    } else {
+      this.props.handleDiscourseSelected(tag);
+    }
+  };
 
   onClickEverything = () => {
     const { deselectedDiscourses } = this.props;
+
+    if (this.state.firstSelection) {
+      this.setState({
+        firstSelection: false,
+      });
+      return;
+    }
+
     const allTags = this.getAvailableDiscourseTags();
     /**
      * If every tag is already selected, then deselect every tag.
@@ -62,6 +92,7 @@ class DiscoursePalette extends React.PureComponent<Props> {
 
   render() {
     const { discourseToColorMap, deselectedDiscourses } = this.props;
+    const { firstSelection: beforeFirstSelection } = this.state;
 
     const filteredDiscourseToColorMap = this.getAvailableDiscourseTags().reduce(
       (obj: { [label: string]: string }, key) => {
@@ -81,9 +112,11 @@ class DiscoursePalette extends React.PureComponent<Props> {
                 <DiscourseTagChip
                   id={d}
                   name={TAG_DISPLAY_NAMES[d] || d}
-                  selected={!deselectedDiscourses.includes(d)}
+                  selected={
+                    !beforeFirstSelection && !deselectedDiscourses.includes(d)
+                  }
                   color={color}
-                  handleSelection={this.props.handleDiscourseSelected}
+                  handleSelection={this.onClickTag}
                 />
               );
             })}
@@ -93,7 +126,9 @@ class DiscoursePalette extends React.PureComponent<Props> {
               id="everything"
               className="everything-chip"
               name={"Everything"}
-              selected={deselectedDiscourses.length === 0}
+              selected={
+                !beforeFirstSelection && deselectedDiscourses.length === 0
+              }
               color={"lightgray"}
               handleSelection={this.onClickEverything}
             />

--- a/ui/src/components/discourse/DiscourseTagChip.tsx
+++ b/ui/src/components/discourse/DiscourseTagChip.tsx
@@ -1,0 +1,36 @@
+import Checkbox from "@material-ui/core/Checkbox";
+import classNames from "classnames";
+import React from "react";
+
+interface Props {
+  id: string;
+  className?: string;
+  name: string;
+  color: string;
+  selected: boolean;
+  handleSelection: (key: string) => void;
+}
+
+export class DiscourseTagChip extends React.PureComponent<Props> {
+  render() {
+    return (
+      <div
+        className={classNames("discourse-chip", this.props.className, {
+          deselected: !this.props.selected,
+        })}
+        onClick={() => this.props.handleSelection(this.props.id)}
+        style={{ backgroundColor: this.props.color }}
+      >
+        <span className="discourse-chip__label">{this.props.name}</span>
+        <Checkbox
+          className="discourse-chip__checkbox"
+          checked={this.props.selected}
+          size="small"
+          color="default"
+        />
+      </div>
+    );
+  }
+}
+
+export default DiscourseTagChip;

--- a/ui/src/components/drawer/Facets.tsx
+++ b/ui/src/components/drawer/Facets.tsx
@@ -31,7 +31,6 @@ export class Facets extends React.PureComponent<Props> {
 
     return (
       <>
-        <p className="discourse-palette-heading">Filter highlights</p>
         <div>
           <DiscoursePalette
             discourseToColorMap={uiUtils.getDiscourseToColorMap()}

--- a/ui/src/style/discourse-tag.less
+++ b/ui/src/style/discourse-tag.less
@@ -32,18 +32,52 @@
   position: relative;
   width: @document-snippets-container-width + 20px;
   margin: 0 auto;
-  margin-top: 5px;
+  padding-top: @padding;
+  position: fixed;
+  background-color: @white;
+  padding-bottom: @padding;
+  border-bottom: 1px solid lightgray;
+  z-index: 2;
+
+  .discourse-palette-header {
+    text-align: center;
+    font-weight: normal;
+    padding-bottom: @padding / 2;
+  }
 
   .discourse-chip-palette {
-    height: fit-content;
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
+    &__tags {
+      height: fit-content;
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+
+      .discourse-chip {
+        /*
+         * Expand buttons to fill drawer, but do not shrink buttons to
+         * the point where their contents will wrap.
+         */
+        flex-shrink: 0;
+        flex-grow: 1;
+      }
+    }
+
+    &__everything {
+      padding-top: @padding / 2;
+    }
 
     .discourse-chip {
+      text-align: center;
+      padding: (@padding / 2) @padding;
       margin: 2px 2px;
       border-radius: 6px !important;
-      opacity: 0.8;
+      border-width: 1px;
+      border-style: solid;
+      border-color: rgba(0, 0, 0, 0);
+      cursor: pointer;
+
+      font-weight: bolder;
+      font-size: @medium;
 
       &.deselected {
         opacity: 0.6;
@@ -53,12 +87,15 @@
         opacity: 1;
         border-color: grey;
       }
-    }
 
-    .discourse-chip-label {
-      vertical-align: middle;
-      font-weight: bold;
-      font-size: 14px;
+      &__label {
+        vertical-align: bottom;
+        padding-right: @padding / 4;
+      }
+
+      &__checkbox {
+        padding: 0;
+      }
     }
   }
 }
@@ -75,10 +112,4 @@
   &:hover {
     z-index: 1000;
   }
-}
-
-.discourse-palette-heading {
-  text-align: center;
-  font-weight: 500;
-  margin-top: 15px;
 }

--- a/ui/src/style/document-snippets.less
+++ b/ui/src/style/document-snippets.less
@@ -1,4 +1,5 @@
 .document-snippets {
+  margin-top: 9rem;
   width: @document-snippets-container-width;
   padding-left: @padding;
   padding-right: @padding;
@@ -86,8 +87,12 @@
   }
 
   @keyframes fadeOut {
-    from {background-color: @border-color; }
-    to {background-color: white; }
+    from {
+      background-color: @border-color;
+    }
+    to {
+      background-color: white;
+    }
   }
 }
 


### PR DESCRIPTION
This PR contributes changes to both the functionality and the appearance of the discourse tag filters.

The first change is around the functionality. Like before, when a reader opens the drawer, they see a list of sentences belonging to all discourse categories. However, _unlike_ before, when a reader clicks on one of the tags, then _only_ that tag gets selected and all others are deselected. This behavior applies for the first tag selection only.

Then, if a reader wish to enable all tags they can click the "Everything" button, which selects all tags. If all tags are selected, the "Everything" button appears selected, and the reader can deselect all tags by clicking the "Everything" button again.

This PR also includes a few style fixes, including:

* the palette of discourse tag filters always shows in the drawer, no matter how far down in the list of sentences the reader scrolls
* the discourse tag buttons have a check box on them to indicate to readers that they can either be turned on or off
* the width of the discourse tag buttons is set adaptively to ensure that the buttons are always flush with the margins of the the drawer

![scim-selections](https://user-images.githubusercontent.com/2358524/135722044-8de274ab-2789-44e2-ba2b-7782cd9b0438.gif)
