### PR TITLE
Move fetch pdf from tex preparation pipeline to sentence pipeline

### DIFF
--- a/data-processing/entities/sentences/__init__.py
+++ b/data-processing/entities/sentences/__init__.py
@@ -1,6 +1,7 @@
 from common.commands.base import CommandList
 from common.commands.detect_entities import make_detect_entities_command
 from common.commands.upload_entities import make_upload_entities_command
+from common.commands.fetch_arxiv_pdf import FetchArxivPdf
 from entities.sentences_pdf.commands.locate_sentences import LocateSentencesCommand
 from entities.sentences_pdf.upload import upload_sentences
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
@@ -10,7 +11,7 @@ from .types import Sentence
 
 from common import directories
 
-commands: CommandList = []
+commands: CommandList = [FetchArxivPdf]
 
 # step 1: detect sentences in latex
 directories.register(f"detected-sentences")

--- a/data-processing/entities/sentences/__init__.py
+++ b/data-processing/entities/sentences/__init__.py
@@ -1,7 +1,6 @@
 from common.commands.base import CommandList
 from common.commands.detect_entities import make_detect_entities_command
 from common.commands.upload_entities import make_upload_entities_command
-from common.commands.fetch_arxiv_pdf import FetchArxivPdf
 from entities.sentences_pdf.commands.locate_sentences import LocateSentencesCommand
 from entities.sentences_pdf.upload import upload_sentences
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
@@ -11,7 +10,7 @@ from .types import Sentence
 
 from common import directories
 
-commands: CommandList = [FetchArxivPdf]
+commands: CommandList = []
 
 # step 1: detect sentences in latex
 directories.register(f"detected-sentences")

--- a/data-processing/entities/sentences_pdf/__init__.py
+++ b/data-processing/entities/sentences_pdf/__init__.py
@@ -1,6 +1,7 @@
 from common.commands.base import CommandList
 from common.commands.base import CommandList
 from common.commands.upload_entities import make_upload_entities_command
+from common.commands.fetch_arxiv_pdf import FetchArxivPdf
 from entities.sentences_pdf.commands.fetch_spp_jsons import FetchSppJsons
 from entities.sentences_pdf.commands.locate_sentences import LocateSentencesCommand
 from scripts.pipelines import EntityPipeline, register_entity_pipeline
@@ -9,7 +10,7 @@ from .upload import upload_sentences
 
 from common import directories
 
-commands: CommandList = []
+commands: CommandList = [FetchArxivPdf]
 
 # step 2: download spp from s3
 directories.register('fetched-spp-jsons')

--- a/data-processing/scripts/commands.py
+++ b/data-processing/scripts/commands.py
@@ -8,9 +8,6 @@ from common.commands.normalize_tex import NormalizeTexSources
 from common.commands.raster_pages import RasterPages
 from common.commands.unpack_sources import UnpackSources
 
-
-from common.commands.fetch_arxiv_pdf import FetchArxivPdf
-
 # Force the importing of modules for entity processing. This forces a call from each of the entity
 # modules to register pipelines for processing each entity. If these aren't imported,
 # 'entity_pipelines' will be empty and all of the commands for processing entities will be missing.

--- a/data-processing/scripts/commands.py
+++ b/data-processing/scripts/commands.py
@@ -7,7 +7,6 @@ from common.commands.fetch_s2_data import FetchS2Metadata
 from common.commands.normalize_tex import NormalizeTexSources
 from common.commands.raster_pages import RasterPages
 from common.commands.unpack_sources import UnpackSources
-from common.commands.fetch_arxiv_pdf import FetchArxivPdf
 
 # Force the importing of modules for entity processing. This forces a call from each of the entity
 # modules to register pipelines for processing each entity. If these aren't imported,
@@ -32,7 +31,6 @@ TEX_PREPARATION_COMMANDS: CommandList = [
     CompileTexSources,
     NormalizeTexSources,
     CompileNormalizedTexSources,
-    FetchArxivPdf,
     RasterPages,
 ]
 

--- a/data-processing/scripts/commands.py
+++ b/data-processing/scripts/commands.py
@@ -8,6 +8,9 @@ from common.commands.normalize_tex import NormalizeTexSources
 from common.commands.raster_pages import RasterPages
 from common.commands.unpack_sources import UnpackSources
 
+
+from common.commands.fetch_arxiv_pdf import FetchArxivPdf
+
 # Force the importing of modules for entity processing. This forces a call from each of the entity
 # modules to register pipelines for processing each entity. If these aren't imported,
 # 'entity_pipelines' will be empty and all of the commands for processing entities will be missing.

--- a/data-processing/scripts/run_pipeline.py
+++ b/data-processing/scripts/run_pipeline.py
@@ -522,7 +522,7 @@ if __name__ == "__main__":
         )
         arxiv_ids = arxiv_ids[: args.max_papers]
 
-    logging.debug(
+    logging.info(
         "The following commands will be run, in this order: %s",
         [CommandClass.get_name() for CommandClass in filtered_commands],
     )


### PR DESCRIPTION
Related ticket: https://github.com/allenai/scholar/issues/31103
### 1.  FileNotFoundError: No PDF found (resolved)
This issue has been resolved in this PR by moving `fetch-arxiv-pdf` step from general tex preparation to `sentence entity` command list. After the changes, the sentence pipeline will still have `fetch-arxiv-pdf`. For `citation entity`, `fetch-arxiv-pdf` step has been removed.

Example running `sentence entity`:
>python scripts/run_pipeline.py   --one-paper-at-a-time   --source arxiv   --arxiv-ids 2001.11963v1   --keep-intermediate-files   --keep-paper-data   --dry-run   --output-forms file   --output-dir outputs-1   --entities **sentences**

Command line result in pipeline order `['fetch-arxiv-sources', 'fetch-s2-metadata', 'unpack-sources', 'compile-tex', 'normalize-tex', 'compile-normalized-tex', 'raster-pages', 'fetch-arxiv-pdf', 'detect-sentences']`:

Example running `sentence entity`:
>python scripts/run_pipeline.py   --one-paper-at-a-time   --source arxiv   --arxiv-ids 2001.11963v1   --keep-intermediate-files   --keep-paper-data   --dry-run   --output-forms file   --output-dir outputs-1   --entities **citations**

Command line result in pipeline order `['fetch-arxiv-sources', 'fetch-s2-metadata', 'unpack-sources', 'compile-tex', 'normalize-tex', 'compile-normalized-tex', 'raster-pages', 'extract-bibitems', 'resolve-bibitems', 'locate-bounding-boxes-for-citation-fragments', 'locate-citations']`

### 2. FileNotFoundError: No .tex found (No changes)

After code review, no fix can be done in the pipeline side as tex preparation step mainly depends on `.tex` file. Exit the pipeline when `.tex` file is missing. 