### PR TITLE
Pipe through mentionless bibs

### DIFF
--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -582,6 +582,7 @@ class CitationData:
     key_s2_ids: Dict[str, str]
     s2_data: Dict[S2Id, SerializableReference]
     bibitem_texts: Optional[Dict[str, str]] = None
+    bibitem_keys: Optional[Set[str]] = None
 
 
 """

--- a/data-processing/common/upload_entities.py
+++ b/data-processing/common/upload_entities.py
@@ -361,6 +361,10 @@ def write_to_file(entity_infos: List[EntityUploadInfo], output_file_name: str) -
         json.dump(to_write, output_file)
 
 
+def upload_info_is_mention(upload_info: EntityUploadInfo) -> bool:
+    return len(upload_info.bounding_boxes) > 0
+
+
 def save_entities(
     s2_id: S2Id,
     arxiv_id: ArxivId,
@@ -378,10 +382,12 @@ def save_entities(
         write_to_file(entity_infos=entity_infos, output_file_name=output_file_name)
 
     if output_details.can_save_to_db():
+        # scholarphi only cares about mentions rn
+        mention_infos = [info for info in entity_infos if upload_info_is_mention(info)]
         logging.info("Saving to db...")
         upload_entities(
             s2_id=s2_id,
             arxiv_id=arxiv_id,
-            entities=entity_infos,
+            entities=mention_infos,
             data_version=data_version,
         )

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -266,6 +266,7 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
             data_version=self.args.data_version,
             output_details=self.output_details,
             filename="citations.json",
+            do_not_save_boundingboxless_to_db=True,
         )
 
     def can_write_to_file(self) -> bool:

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -241,6 +241,24 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
                 )
                 entity_infos.append(entity_info)
 
+        # what downstream systems call 'entities' - no bounding boxes
+        # this is a little more specific than what scholarphi calls an
+        # entity
+        for bibitem_key in bibitem_keys:
+            entity_data = self._entity_data_from_text_and_matches(
+                arxiv_id=item.arxiv_id,
+                bibitem_texts=bibitem_texts,
+                key_s2_ids=key_s2_ids,
+                bibitem_key=bibitem_key,
+            )
+            entity_info = EntityUploadInfo(
+                id_=bibitem_key,
+                type_="citation",
+                bounding_boxes=[],
+                data=entity_data,
+            )
+            entity_infos.append(entity_info)
+
         save_entities(
             s2_id=item.s2_id,
             arxiv_id=item.arxiv_id,

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -172,7 +172,7 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
                 s2_data[metadata.s2_id] = metadata
 
             yield CitationData(
-                arxiv_id, s2_id, citation_locations, key_s2_ids, s2_data, bibitem_texts
+                arxiv_id, s2_id, citation_locations, key_s2_ids, s2_data, bibitem_texts, bibitem_keys
             )
 
     def process(self, _: CitationData) -> Iterator[None]:
@@ -182,9 +182,11 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
         citation_locations = item.citation_locations
         key_s2_ids = item.key_s2_ids
         bibitem_texts = item.bibitem_texts
+        bibitem_keys = item.bibitem_keys
 
         # for mypy
         assert bibitem_texts is not None
+        assert bibitem_keys is not None
 
         entity_infos = []
 

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -46,13 +46,13 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
         """
         return maybe_str is not None and maybe_str.strip() != ""
 
-    def _get_bibitem_keys_from_bibitems(self, bibitems: List[Bibitem]) -> Set[str]:
+    def _get_bibitem_keys_from_bibitems(self, arxiv_id: ArxivId, bibitems: List[Bibitem]) -> Set[str]:
         list_version = [item.id_ for item in bibitems if self._acceptable_str(item.id_)]
         if len(list_version) < len(bibitems):
-            logging.warning("Some bibitems have empty keys.")
+            logging.warning("Some bibitems have empty keys for paper %s.", arxiv_id)
         set_version = set(list_version)
         if len(set_version) < len(list_version):
-            logging.warning("Some bibitems have the same key.")
+            logging.warning("Some bibitems have the same key for paper %s.", arxiv_id)
         return set_version
 
     def _get_bibitem_texts_from_bibitems(
@@ -114,6 +114,7 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
                 )
                 continue
             bibitems = list(file_utils.load_from_csv(bibitems_path, Bibitem))
+            bibitem_keys: Set[str] = self._get_bibitem_keys_from_bibitems(arxiv_id, bibitems)
             bibitem_texts: Dict[str, str] = self._get_bibitem_texts_from_bibitems(
                 arxiv_id,
                 bibitems,

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -190,7 +190,7 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
 
         entity_infos = []
 
-        citation_index = 0
+        # mentions - all mentions have at least one bounding box
         for citation_key, locations in citation_locations.items():
 
             entity_data: EntityData = {
@@ -224,7 +224,6 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
                     data=entity_data,
                 )
                 entity_infos.append(entity_info)
-                citation_index += 1
 
         save_entities(
             s2_id=item.s2_id,

--- a/data-processing/tests/common/test_upload_entities.py
+++ b/data-processing/tests/common/test_upload_entities.py
@@ -103,7 +103,7 @@ def test_save_entities_considers_boundingboxless_arg():
                 do_not_save_boundingboxless_to_db=False,
             )
 
-            # do_not_save_boundingboxless_to_db=False
+            # do_not_save_boundingboxless_to_db=True
             save_entities(
                 s2_id=s2_id,
                 arxiv_id=arxiv_id,
@@ -126,22 +126,26 @@ def test_save_entities_considers_boundingboxless_arg():
                 entities=[item_with_bb],
                 data_version=data_version,
             )
-            write_to_file_false = call(
+            write_to_file_call_false = call(
                 entity_infos=items,
                 output_file_name=filename,
             )
-            write_to_file_true = call(
+            write_to_file_call_true = call(
                 entity_infos=items,
                 output_file_name=filename,
             )
 
-            assert mock_upload_entities.assert_has_calls(
-                upload_entity_call_false,
-                upload_entity_call_true,
+            mock_upload_entities.assert_has_calls(
+                [
+                    upload_entity_call_false,
+                    upload_entity_call_true,
+                ]
             )
-            assert mock_write_to_file.assert_has_calls(
-                write_to_file_false,
-                write_to_file_true,
+            mock_write_to_file.assert_has_calls(
+                [
+                    write_to_file_call_false,
+                    write_to_file_call_true,
+                ]
             )
 
 def test_output_details_validation_db_no_dir():

--- a/data-processing/tests/common/test_upload_entities.py
+++ b/data-processing/tests/common/test_upload_entities.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
 from common.upload_entities import OutputDetails, save_entities
+from common.types import BoundingBox, EntityUploadInfo
 
 
 def test_save_entities_with_file():
@@ -58,6 +59,90 @@ def test_save_entities_with_both():
             assert mock_upload_entities.called
             assert mock_write_to_file.called
 
+
+def test_save_entities_considers_boundingboxless_arg():
+    output_details = OutputDetails(["file", "db"], "bye")
+
+    item_with_bb = EntityUploadInfo(
+        id_="hi",
+        type_="citation",
+        bounding_boxes=[
+            BoundingBox(
+                left=0.1,
+                top=0.2,
+                width=0.3,
+                height=0.4,
+                page=5,
+            )
+        ],
+        data={"key": "hello"},
+    )
+    item_without_bb = EntityUploadInfo(
+        id_="bye",
+        type_="citation",
+        bounding_boxes=[],
+        data={"key": "goodbye"},
+    )
+    items = [item_with_bb, item_without_bb]
+
+    with patch("common.upload_entities.upload_entities") as mock_upload_entities:
+        with patch("common.upload_entities.write_to_file") as mock_write_to_file:
+            s2_id = "s2id"
+            arxiv_id = "arxivid"
+            data_version = None
+            filename = "something.json"
+
+            # do_not_save_boundingboxless_to_db=False
+            save_entities(
+                s2_id=s2_id,
+                arxiv_id=arxiv_id,
+                entity_infos=items,
+                data_version=None,
+                output_details=output_details,
+                filename=filename,
+                do_not_save_boundingboxless_to_db=False,
+            )
+
+            # do_not_save_boundingboxless_to_db=False
+            save_entities(
+                s2_id=s2_id,
+                arxiv_id=arxiv_id,
+                entity_infos=items,
+                data_version=None,
+                output_details=output_details,
+                filename=filename,
+                do_not_save_boundingboxless_to_db=True,
+            )
+
+            upload_entity_call_false = call(
+                s2_id=s2_id,
+                arxiv_id=arxiv_id,
+                entities=items,
+                data_version=data_version,
+            )
+            upload_entity_call_true = call(
+                s2_id=s2_id,
+                arxiv_id=arxiv_id,
+                entities=[item_with_bb],
+                data_version=data_version,
+            )
+            write_to_file_false = call(
+                entity_infos=items,
+                output_file_name=filename,
+            )
+            write_to_file_true = call(
+                entity_infos=items,
+                output_file_name=filename,
+            )
+
+            assert mock_upload_entities.assert_has_calls(
+                upload_entity_call_false,
+                upload_entity_call_true,
+            )
+            assert mock_write_to_file.assert_has_calls(
+                write_to_file_false,
+                write_to_file_true,
+            )
 
 def test_output_details_validation_db_no_dir():
     # just check this doesn't throw an error

--- a/data-processing/tests/common/test_upload_entities.py
+++ b/data-processing/tests/common/test_upload_entities.py
@@ -126,13 +126,15 @@ def test_save_entities_considers_boundingboxless_arg():
                 entities=[item_with_bb],
                 data_version=data_version,
             )
+
+            output_path = f"{output_details.output_dir}/{filename}"
             write_to_file_call_false = call(
                 entity_infos=items,
-                output_file_name=filename,
+                output_file_name=output_path,
             )
             write_to_file_call_true = call(
                 entity_infos=items,
-                output_file_name=filename,
+                output_file_name=output_path,
             )
 
             mock_upload_entities.assert_has_calls(


### PR DESCRIPTION
Related to https://github.com/allenai/scholar/issues/32733, and https://github.com/allenai/scholar/issues/32730.

This PR adjusts the code that saves citation items to include, for each reference, a representation of it independent of its inline mentions (if any). This allows us to have some representation of references that we have no inline mentions for, which is the goal.

I've made it so that these additional items are only saved in the file version of the output, not in the scholarphi DB too, because:
a) We want this extra info for the new reader, and the new reader only looks in the file version of the output.
b) I think confirming that it does not adversely affect things using the db version of the output would be a non-trivial amount  more work than doing the relevant part of what's in this PR, and I don't think that the relevant part of what's in this PR introduces that much additional complexity.

Testing done:
I've got corresponding changes for scholarphi-pipeline and s2airs [here](https://github.com/allenai/scholarphi-pipeline/pull/152) and [here](https://github.com/allenai/s2airs/pull/79). I ran a couple of papers through the three systems including the changes, and put details in https://github.com/allenai/scholar/issues/32733. Summary: for both papers, we had the additional items representing references independent of inline mentions. This included, for the one paper where it was expected, references that had no inline mentions.