### PR TITLE
Switch to new public API endpoint, and deprecate partner subdomain

### DIFF
--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -118,13 +118,9 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
     ),
   };
   if (apiKey) {
-    conf.headers['x-api-key'] = apiKey;
+    conf.headers['x-api-key'] = apiKey; // TODO: should I keep this around?  Asking Rodney https://github.com/allenai/scholar/issues/32158#issuecomment-1487492642
   }
-  const apiOrigin = (
-    apiKey
-      ? "https://partner.semanticscholar.org/v1"
-      : "https://api.semanticscholar.org/v1"
-  );
+  const apiOrigin = "https://api.semanticscholar.org/graph/v1";
 
   return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -118,7 +118,7 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
     ),
   };
   if (apiKey) {
-    conf.headers['x-api-key'] = apiKey; // TODO: should I keep this around?  Asking Rodney https://github.com/allenai/scholar/issues/32158#issuecomment-1487492642
+    conf.headers['x-api-key'] = apiKey;
   }
   const apiOrigin = "https://api.semanticscholar.org/graph/v1";
 

--- a/data-processing/common/commands/fetch_s2_data.py
+++ b/data-processing/common/commands/fetch_s2_data.py
@@ -48,7 +48,7 @@ class S2ReferencesNotFoundException(S2MetadataException):
 class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
     def __init__(self, args: Any) -> None:
         super().__init__(args)
-        self._partner_api_token = os.getenv("S2_PARTNER_API_TOKEN", None)
+        # self._partner_api_token = os.getenv("S2_PARTNER_API_TOKEN", None) # TODO: is this used anywhere else though???
 
     def _mk_api_request(self, arxivId: ArxivId) -> requests.Response:
         # XXX(andrewhead): S2 API does not have versions of arXiv papers. I don't think this
@@ -58,9 +58,9 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
         base_url = "api.semanticscholar.org"
         headers = None
 
-        if self._partner_api_token:
-            base_url = "partner.semanticscholar.org"
-            headers = {"x-api-key": self._partner_api_token}
+        # if self._partner_api_token:
+        #     base_url = "partner.semanticscholar.org"
+        #     headers = {"x-api-key": self._partner_api_token}
 
         logger.info(f"Issuing request to S2 @ {base_url}")
 

--- a/data-processing/common/commands/fetch_s2_data.py
+++ b/data-processing/common/commands/fetch_s2_data.py
@@ -62,10 +62,13 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
         #     base_url = "partner.semanticscholar.org"
         #     headers = {"x-api-key": self._partner_api_token}
 
+        references_fields = ["authors", "title", "externalIds", "venue", "year"]
+        fields_query = "fields=references." + ",references.".join(references_fields)
+
         logger.info(f"Issuing request to S2 @ {base_url}")
 
         return requests.get(
-            f"https://{base_url}/v1/paper/arXiv:{versionless_id}",
+            f"https://{base_url}/graph/v1/paper/arXiv:{versionless_id}?{fields_query}",
             headers=headers
         )
 
@@ -75,7 +78,7 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
 
     @staticmethod
     def get_description() -> str:
-        return "Fetch S2 metadata for papers. Includes reference information."
+        return "Fetch S2 metadata for a paper, includes its references' titles, authors, and various IDs"
 
     def get_arxiv_ids_dirkey(self) -> str:
         return "sources-archives"
@@ -99,13 +102,25 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
                 data = resp.json()
                 references = []
                 for reference_data in data["references"]:
+
+                    if reference_data["paperId"]:
+                        external_ids = reference_data["externalIds"]
+                        if external_ids:
+                            corpus_id = external_ids.get("CorpusId")  # all canonical papers have a CorpusId
+                            arxiv_id = external_ids.get("ArXiv")    # may be None
+                            doi = external_ids.get("DOI")           # may be None
+                        else:
+                            corpus_id = arxiv_id = doi = None
+
                     authors = []
                     for author_data in reference_data["authors"]:
                         authors.append(Author(author_data["authorId"], author_data["name"]))
+
                     reference = Reference(
                         s2_id=reference_data["paperId"],
-                        arxivId=reference_data["arxivId"],
-                        doi=reference_data["doi"],
+                        # corpus_id=corpus_id,  # TODO: do we care to do this for main branch?
+                        arxivId=arxiv_id,
+                        doi=doi,
                         title=reference_data["title"],
                         authors=authors,
                         venue=reference_data["venue"],

--- a/data-processing/common/commands/fetch_s2_data.py
+++ b/data-processing/common/commands/fetch_s2_data.py
@@ -102,11 +102,10 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
                 references = []
                 for reference_data in data["references"]:
 
-                    corpus_id = arxiv_id = doi = None
+                    arxiv_id = doi = None
                     if reference_data["paperId"]:
                         external_ids = reference_data["externalIds"]
                         if external_ids:
-                            corpus_id = external_ids.get("CorpusId")  # all canonical papers have a CorpusId
                             arxiv_id = external_ids.get("ArXiv")    # may be None
                             doi = external_ids.get("DOI")           # may be None
 
@@ -116,7 +115,6 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
 
                     reference = Reference(
                         s2_id=reference_data["paperId"],
-                        # corpus_id=corpus_id,  # TODO: do we care to do this for main branch?
                         arxivId=arxiv_id,
                         doi=doi,
                         title=reference_data["title"],

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -14,9 +14,6 @@ from common.commands.fetch_s2_data import (
 )
 from scripts.commands import run_command
 
-expected_references_fields = ["authors", "title", "externalIds", "venue", "year"]
-expected_fields_query = "fields=references." + ",references.".join(expected_references_fields)
-
 
 @dataclass
 class Args:
@@ -33,9 +30,11 @@ def test_makes_request_over_public_api_in_absence_of_token():
 
             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
             command._mk_api_request("fakeid")
+            fields = ["references." + f for f in ["authors", "title", "externalIds", "venue", "year"]]
 
             mock_requests.get.assert_called_with(
-                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid",
+                params={"fields": ",".join(fields)},
                 headers=None
             )
 
@@ -49,8 +48,11 @@ def test_makes_request_over_public_api_when_token_present():
 
             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
             command._mk_api_request("fakeid")
+            fields = ["references." + f for f in ["authors", "title", "externalIds", "venue", "year"]]
+
             mock_requests.get.assert_called_with(
-                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid",
+                params={"fields": ",".join(fields)},
                 headers={"x-api-key": "some_token"}
             )
 

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -21,19 +21,20 @@ class Args:
     arxiv_ids_file = None
 
 
-def test_makes_request_over_public_api_in_absence_of_partner_token():
-    with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
-        mock_getenv.return_value = None
+def test_makes_request_over_public_api():
+    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+        mock_requests.get.return_value = Mock()
 
-        with patch("common.commands.fetch_s2_data.requests") as mock_requests:
-            mock_requests.get.return_value = Mock()
+        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+        command._mk_api_request("fakeid")
 
-            command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
-            command._mk_api_request("fakeid")
-            mock_requests.get.assert_called_with(
-                "https://api.semanticscholar.org/v1/paper/arXiv:fakeid",
-                headers=None
-            )
+        expected_references_fields = ["authors", "title", "externalIds", "venue", "year"]
+        expected_fields_query = "fields=references." + ",references.".join(expected_references_fields)
+
+        mock_requests.get.assert_called_with(
+            f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+            headers=None
+        )
 
 
 # def test_makes_request_over_partner_api_when_token_present():

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -14,6 +14,9 @@ from common.commands.fetch_s2_data import (
 )
 from scripts.commands import run_command
 
+expected_references_fields = ["authors", "title", "externalIds", "venue", "year"]
+expected_fields_query = "fields=references." + ",references.".join(expected_references_fields)
+
 
 @dataclass
 class Args:
@@ -21,35 +24,35 @@ class Args:
     arxiv_ids_file = None
 
 
-def test_makes_request_over_public_api():
-    with patch("common.commands.fetch_s2_data.requests") as mock_requests:
-        mock_requests.get.return_value = Mock()
+def test_makes_request_over_public_api_in_absence_of_token():
+    with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
+        mock_getenv.return_value = None
 
-        command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
-        command._mk_api_request("fakeid")
+        with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+            mock_requests.get.return_value = Mock()
 
-        expected_references_fields = ["authors", "title", "externalIds", "venue", "year"]
-        expected_fields_query = "fields=references." + ",references.".join(expected_references_fields)
+            command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+            command._mk_api_request("fakeid")
 
-        mock_requests.get.assert_called_with(
-            f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
-            headers=None
-        )
+            mock_requests.get.assert_called_with(
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                headers=None
+            )
 
 
-# def test_makes_request_over_partner_api_when_token_present():
-#     with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
-#         mock_getenv.side_effect = lambda x, y: "some_token" if x == 'S2_PARTNER_API_TOKEN' else None
-#
-#         with patch("common.commands.fetch_s2_data.requests") as mock_requests:
-#             mock_requests.get.return_value = Mock()
-#
-#             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
-#             command._mk_api_request("fakeid")
-#             mock_requests.get.assert_called_with(
-#                 "https://partner.semanticscholar.org/v1/paper/arXiv:fakeid",
-#                 headers={"x-api-key": "some_token"}
-#             )
+def test_makes_request_over_public_api_when_token_present():
+    with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
+        mock_getenv.side_effect = lambda x, y: "some_token" if x == 'S2_PARTNER_API_TOKEN' else None
+
+        with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+            mock_requests.get.return_value = Mock()
+
+            command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+            command._mk_api_request("fakeid")
+            mock_requests.get.assert_called_with(
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                headers={"x-api-key": "some_token"}
+            )
 
 
 def test_no_s2_paper_raises_exception():

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -36,19 +36,19 @@ def test_makes_request_over_public_api_in_absence_of_partner_token():
             )
 
 
-def test_makes_request_over_partner_api_when_token_present():
-    with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
-        mock_getenv.side_effect = lambda x, y: "some_token" if x == 'S2_PARTNER_API_TOKEN' else None
-
-        with patch("common.commands.fetch_s2_data.requests") as mock_requests:
-            mock_requests.get.return_value = Mock()
-
-            command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
-            command._mk_api_request("fakeid")
-            mock_requests.get.assert_called_with(
-                "https://partner.semanticscholar.org/v1/paper/arXiv:fakeid",
-                headers={"x-api-key": "some_token"}
-            )
+# def test_makes_request_over_partner_api_when_token_present():
+#     with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
+#         mock_getenv.side_effect = lambda x, y: "some_token" if x == 'S2_PARTNER_API_TOKEN' else None
+#
+#         with patch("common.commands.fetch_s2_data.requests") as mock_requests:
+#             mock_requests.get.return_value = Mock()
+#
+#             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
+#             command._mk_api_request("fakeid")
+#             mock_requests.get.assert_called_with(
+#                 "https://partner.semanticscholar.org/v1/paper/arXiv:fakeid",
+#                 headers={"x-api-key": "some_token"}
+#             )
 
 
 def test_no_s2_paper_raises_exception():


### PR DESCRIPTION

* Parent task = [Switch scholarphi to new public API endpoint #32158](https://github.com/allenai/scholar/issues/32158#top)
  * As seen in [comment/question](https://github.com/allenai/scholar/issues/32158#issuecomment-1456799584), we have 2 goals:
    * GOAL 1 = use the latest `graph/v1/` endpoint instead of legacy `v1/` endpoint
    * GOAL 2 = use the regular `api.semanticscholar.org` subdomain, instead of an optional `partner.semanticscholar.org` subdomain.
      * Question: before, users with `S2_PARTNER_API_TOKEN` env were calling the partner domain for higher rate limit.  Can we use the same token on the regular `api.semantic.org` subdomain?   
        * [Rodney says yes](https://github.com/allenai/scholar/issues/32158#issuecomment-1487492642).

* THIS PR is for the `main` branch.
  * Goal 1 was done in the `chi-2021-demo` branch as seen in this PR: #377 
    * So we'll be using that as a reference, MINUS the changes made for adding corpus IDs of citations. 
  * Goal 2 was done in the `chi-2021-demo` branch as seen in this PR: #382 
    * So we used that as a reference as well.

