### PR TITLE
Deprecate partner subdomain

### DIFF
--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -120,11 +120,7 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
   if (apiKey) {
     conf.headers['x-api-key'] = apiKey;
   }
-  const apiOrigin = (
-    apiKey
-      ? "https://partner.semanticscholar.org/v1"
-      : "https://api.semanticscholar.org/v1"
-  );
+  const apiOrigin = "https://api.semanticscholar.org/graph/v1";
 
   return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -120,11 +120,7 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
   if (apiKey) {
     conf.headers['x-api-key'] = apiKey;
   }
-  const apiOrigin = (
-    apiKey
-      ? "https://partner.semanticscholar.org/v1"
-      : "https://api.semanticscholar.org/v1"
-  );
+  const apiOrigin = "https://api.semanticscholar.org/v1";
 
   return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -120,7 +120,11 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
   if (apiKey) {
     conf.headers['x-api-key'] = apiKey;
   }
-  const apiOrigin = "https://api.semanticscholar.org/graph/v1";
+  const apiOrigin = (
+    apiKey
+      ? "https://partner.semanticscholar.org/v1"
+      : "https://api.semanticscholar.org/v1"
+  );
 
   return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -120,7 +120,11 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
   if (apiKey) {
     conf.headers['x-api-key'] = apiKey;
   }
-  const apiOrigin = "https://api.semanticscholar.org/v1";
+  const apiOrigin = (
+    apiKey
+      ? "https://partner.semanticscholar.org/v1"
+      : "https://api.semanticscholar.org/v1"
+  );
 
   return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }

--- a/data-processing/common/commands/fetch_s2_data.py
+++ b/data-processing/common/commands/fetch_s2_data.py
@@ -25,7 +25,7 @@ class S2ApiException(Exception):
 
 class S2ApiRateLimitingException(S2ApiException):
     """
-    Caller has been rate-limited by S2's Public/Partner API.
+    Caller has been rate-limited by S2's Public API.
     """
 
 class S2MetadataException(S2ApiException):
@@ -59,7 +59,6 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
         headers = None
 
         if self._partner_api_token:
-            base_url = "partner.semanticscholar.org"
             headers = {"x-api-key": self._partner_api_token}
 
         logger.info(f"Issuing request to S2 @ {base_url}")
@@ -78,7 +77,7 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
 
     @staticmethod
     def get_description() -> str:
-        return "Fetch S2 metadata for a paper, specifically its references' titles, authors, and various IDs"
+        return "Fetch S2 metadata for a paper, including its references' titles, authors, and various IDs"
 
     def get_arxiv_ids_dirkey(self) -> str:
         return "sources-archives"

--- a/data-processing/common/commands/fetch_s2_data.py
+++ b/data-processing/common/commands/fetch_s2_data.py
@@ -61,13 +61,13 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
         if self._partner_api_token:
             headers = {"x-api-key": self._partner_api_token}
 
+        fields = ["references." + f for f in ["authors", "title", "externalIds", "venue", "year"]]
+
         logger.info(f"Issuing request to S2 @ {base_url}")
 
-        references_fields = ["authors", "title", "externalIds", "venue", "year"]
-        fields_query = "fields=references." + ",references.".join(references_fields)
-
         return requests.get(
-            f"https://{base_url}/graph/v1/paper/arXiv:{versionless_id}?{fields_query}",
+            f"https://{base_url}/graph/v1/paper/arXiv:{versionless_id}",
+            params={"fields": ",".join(fields)},
             headers=headers
         )
 
@@ -77,7 +77,7 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
 
     @staticmethod
     def get_description() -> str:
-        return "Fetch S2 metadata for a paper, including its references' titles, authors, and various IDs"
+        return "Fetch S2 metadata for a paper, includes its references' titles, authors, and various IDs"
 
     def get_arxiv_ids_dirkey(self) -> str:
         return "sources-archives"
@@ -100,16 +100,12 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
             if resp.ok:
                 data = resp.json()
                 references = []
+                unmatched_references = 0  # https://github.com/allenai/scholarphi/pull/381#discussion_r1151224885
                 for reference_data in data["references"]:
-
                     if reference_data["paperId"]:
-                        external_ids = reference_data["externalIds"]
-                        if external_ids:
-                            corpus_id = external_ids.get("CorpusId")  # all canonical papers have a CorpusId
-                            arxiv_id = external_ids.get("ArXiv")    # may be None
-                            doi = external_ids.get("DOI")           # may be None
-                        else:
-                            corpus_id = arxiv_id = doi = None
+                        corpus_id = reference_data.get("externalIds", {}).get("CorpusId")  # all canonical papers got it
+                        arxiv_id = reference_data.get("externalIds", {}).get("ArXiv")   # may be None
+                        doi = reference_data.get("externalIds", {}).get("DOI")          # may be None
 
                         authors = []
                         for author_data in reference_data["authors"]:
@@ -126,13 +122,16 @@ class FetchS2Metadata(ArxivBatchCommand[ArxivId, S2Metadata]):
                             year=reference_data["year"],
                         )
                         references.append(reference)
+                    else:
+                        unmatched_references += 1
 
                 if not references:
                     # References are required to process citations, mark job as failed
                     raise S2ReferencesNotFoundException()
 
                 s2_metadata = S2Metadata(s2_id=data["paperId"], references=references)
-                logging.debug("Fetched S2 metadata for arXiv paper %s", item)
+                logging.debug(f"Fetched S2 metadata for arXiv paper {item}, "
+                              f"and omitted {unmatched_references} unmatched references.")
                 yield s2_metadata
             elif resp.status_code == 404:
                 # Paper is unavailable in Public API -- potential race condition.

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -14,9 +14,6 @@ from common.commands.fetch_s2_data import (
 )
 from scripts.commands import run_command
 
-expected_references_fields = ["authors", "title", "externalIds", "venue", "year"]
-expected_fields_query = "fields=references." + ",references.".join(expected_references_fields)
-
 
 @dataclass
 class Args:
@@ -33,8 +30,11 @@ def test_makes_request_over_public_api_in_absence_of_token():
 
             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
             command._mk_api_request("fakeid")
+            fields = ["references." + f for f in ["authors", "title", "externalIds", "venue", "year"]]
+
             mock_requests.get.assert_called_with(
-                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid",
+                params={"fields": ",".join(fields)},
                 headers=None
             )
 
@@ -48,8 +48,11 @@ def test_makes_request_over_public_api_when_token_present():
 
             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
             command._mk_api_request("fakeid")
+            fields = ["references." + f for f in ["authors", "title", "externalIds", "venue", "year"]]
+
             mock_requests.get.assert_called_with(
-                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid",
+                params={"fields": ",".join(fields)},
                 headers={"x-api-key": "some_token"}
             )
 

--- a/data-processing/tests/common/commands/test_fetch_s2_data.py
+++ b/data-processing/tests/common/commands/test_fetch_s2_data.py
@@ -24,7 +24,7 @@ class Args:
     arxiv_ids_file = None
 
 
-def test_makes_request_over_public_api_in_absence_of_partner_token():
+def test_makes_request_over_public_api_in_absence_of_token():
     with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
         mock_getenv.return_value = None
 
@@ -39,7 +39,7 @@ def test_makes_request_over_public_api_in_absence_of_partner_token():
             )
 
 
-def test_makes_request_over_partner_api_when_token_present():
+def test_makes_request_over_public_api_when_token_present():
     with patch("common.commands.fetch_s2_data.os.getenv") as mock_getenv:
         mock_getenv.side_effect = lambda x, y: "some_token" if x == 'S2_PARTNER_API_TOKEN' else None
 
@@ -49,7 +49,7 @@ def test_makes_request_over_partner_api_when_token_present():
             command = FetchS2Metadata(Args(arxiv_ids=['fakeid']))
             command._mk_api_request("fakeid")
             mock_requests.get.assert_called_with(
-                f"https://partner.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
+                f"https://api.semanticscholar.org/graph/v1/paper/arXiv:fakeid?{expected_fields_query}",
                 headers={"x-api-key": "some_token"}
             )
 


### PR DESCRIPTION
* Parent task = [Switch scholarphi to new public API endpoint #32158](https://github.com/allenai/scholar/issues/32158#top)
  * As seen in [comment/question](https://github.com/allenai/scholar/issues/32158#issuecomment-1456799584), we have 2 goals:
    * GOAL 1 = use the latest `graph/v1/` endpoint instead of legacy `v1/` endpoint
    * GOAL 2 = use the regular `api.semanticscholar.org` subdomain, instead of an optional `partner.semanticscholar.org` subdomain.
      * Question: before, users with `S2_PARTNER_API_TOKEN` env were calling the partner domain for higher rate limit.  Can we use the same token on the regular `api.semantic.org` subdomain?   
        * [Rodney says yes](https://github.com/allenai/scholar/issues/32158#issuecomment-1487492642).

* THIS PR is for the `chi-2021-demo` branch.
  * Goal 1 is already done in this PR: #377 
  * Goal 2 is the change we're making here.

-------
also plz ignore the branch name `gh35326_chi2021demo` where it referenced the wrong parent ticket lol


TESTING 👍 
------
* Deploy locally, then run pipeline on an example paper.  
  * Basically the same steps seen in IDEA 2C in this [ticket](https://github.com/allenai/scholarphi/pull/377))
  * **Do this WITHOUT a partner API key**, logs should show the same.
    * This is prob not necessary but I'm gonna test it out just in case. 
    * Yup, I see the same results as the reference ticket above! (The log starting with `>>>` is temporary and is not in PR)
    * ![Screen Shot 2023-03-29 at 12 19 38 PM](https://user-images.githubusercontent.com/47910008/228645178-c7747dfa-b66f-4efe-a166-f00cf985e35e.png)
  * **Do this WITH a partner API key**, logs should show that it's being sent to the `api.semanticscholar.org` subdomain.
    * Lots of existing partner API keys available, I'm just going to borrow `[s2-partner-conference-api`](https://us-west-2.console.aws.amazon.com/apigateway/home?region=us-west-2#/api-keys/m6l2m75vif) for now. 
    * Yup, I see that it's no longer calling the partner subdomain!
    * ![Screen Shot 2023-03-29 at 12 23 46 PM](https://user-images.githubusercontent.com/47910008/228646062-e67f828c-59b5-42d6-b29c-fd0dd2f9e6cd.png)
    * Looked at the `data-processing/data/citations.json` produced and it's legit!
