### PR TITLE
deprecate partner subdomain for s2-api.ts

### DIFF
--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -120,11 +120,7 @@ export function getPaperUncached(s2Id: string, apiKey?: string): AxiosPromise<Pa
   if (apiKey) {
     conf.headers['x-api-key'] = apiKey;
   }
-  const apiOrigin = (
-    apiKey
-      ? "https://partner.semanticscholar.org/v1"
-      : "https://api.semanticscholar.org/v1"
-  );
+  const apiOrigin = "https://api.semanticscholar.org/v1";
 
   return axios.get<Paper>(`${apiOrigin}/paper/${s2Id}`, conf);
 }


### PR DESCRIPTION
[As mentioned](https://github.com/allenai/scholarphi/pull/382#issuecomment-1489084596) in preceding [Deprecate partner subdomain #382](https://github.com/allenai/scholarphi/pull/382#top) (which takes care of the `data-processing/` side), this PR is for the `api` side.

BTW, the changes here are already approved for the `main` branch in PR #381 .  We're just trying to maintain some kind of consistency between the 2 branches here.  

Also, we're pretty sure that NOBODY is even calling the `api` code in scholarphi anymore, but IF things were to blow up, then we know to reverse this PR (for this branch or for `main` branch, depending on what happens).